### PR TITLE
Phase 1: rholang-bytecode crate configuration with basic bytecode instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "shell",
     "rholang-tree-sitter",
     "rholang-parser",
-    "rholang-jni-bridge"
+    "rholang-jni-bridge",
+    "rholang-bytecode"
 ]
 
 [workspace.dependencies]
@@ -49,6 +50,13 @@ serde_json = "1.0.107"
 
 # Used by: rholang-jni-bridge
 jni = "0.21.1"
+
+# Used by: rholang-bytecode
+bincode = "*"
+
+# For error handling
+thiserror = "*"
+
 
 [profile.dev]
 debug = true

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ test-all:
 test-shell:
 	cargo test -p shell
 
+# Run the rholang-bytecode examples
+.PHONY: bytecode-examples
+macro-examples:
+	 cargo run --example core_types_example -p rholang-bytecode
+
 # Check code quality
 .PHONY: check
 check:

--- a/docs/BYTECODE.md
+++ b/docs/BYTECODE.md
@@ -1,0 +1,168 @@
+We need functionality that can implement AST in bytecode for the future VM.
+Since the task is enormous, I divided it into phases with subtasks.
+
+## Phases
+
+### Phase 1: Crate Setup & Core Types
+
+First things first - we need to get the foundation in place:
+
+- Set up the `rholang-bytecode` crate
+    - Create a sensible crate structure with appropriate modules
+    - Configure dependencies and features we'll need
+    - Get documentation and examples started early
+- Define our core data types for bytecode representation
+    - Build a Value type to represent Rholang values (integers, strings, booleans, etc.)
+    - Implement a Name type for Rholang names
+    - Create data structures for literals and constants
+
+### Phase 2: Instruction Set Definition
+
+We're drawing inspiration from the old protocode implementation for our instruction set. Here's what we need to support all Rholang language features:
+
+- Stack Operations
+    - `Push`: Push a value onto the stack *(not in current grammar)*
+    - `Pop`: Remove the top value from the stack *(not in current grammar)*
+    - `Dup`: Duplicate the top value on the stack *(not in current grammar)*
+    - `Swap`: Swap the top two values on the stack *(not in current grammar)*
+    - `Rot`: Rotate the top three values on the stack *(not in current grammar)*
+- Arithmetic Instructions
+    - `Add`, `Sub`, `Mul`, `Div`, `Mod`: The usual arithmetic suspects *(all present in grammar)*
+- Logical Instructions
+    - `And`, `Or`, `Not`: Boolean operations *(all present in grammar)*
+    - `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`: Comparison operations *(all present in grammar)*
+- Process Instructions
+    - `Par`: Parallel composition of processes *(present in grammar)*
+    - `Send`: Send a message on a channel *(present in grammar)*
+    - `Receive`: Receive a message from a channel *(present in grammar as "input")*
+    - `New`: Create a new name *(present in grammar)*
+- Control Flow Instructions
+    - `Jump`, `JumpIf`, `JumpIfNot`: Conditional and unconditional jumps *(not in current grammar)*
+    - `Call`, `Return`: Function call and return *(not in current grammar)*
+    - `CallBuiltin`: Call a built-in function *(not in current grammar)*
+    - `Match`, `MatchCase`: Pattern matching *(present in grammar)*
+- Memory Instructions
+    - `Load`, `Store`: Global variable access *(not in current grammar)*
+    - `LoadLocal`, `StoreLocal`: Local variable access *(not in current grammar)*
+    - `PushEnv`, `PopEnv`: Environment management *(not in current grammar)*
+- Data Structure Instructions
+    - List operations: `ListNew`, `ListPush`, `ListPop`, `ListGet` *(not in current grammar, though list syntax exists)*
+    - Map operations: `MapNew`, `MapInsert`, `MapGet`, `MapRemove` *(not in current grammar, though map syntax exists)*
+    - Tuple operations: `TupleNew`, `TupleGet` *(not in current grammar, though tuple syntax exists)*
+- Built-in Instructions
+    - String operations: `StringConcat`, `StringLength`, `StringSlice` *(not in current grammar)*
+- Quoting Instructions
+    - Instructions for handling quoted processes and names *(present in grammar)*
+
+### Phase 3: Bytecode Program Structure
+
+Once we have our instructions defined, we need to organize them into a coherent program structure:
+
+- Instruction Encoding
+    - Define a compact binary format for instructions
+    - Implement encoding and decoding functions (we'll need both)
+- Bytecode Chunk and Program Structure
+    - Create a structure for bytecode chunks (sequences of instructions)
+    - Build the bytecode program as a collection of chunks
+    - Add useful metadata for debugging and optimization
+- Serialization
+    - Implement serialization/deserialization of bytecode programs
+    - Support multiple formats (binary for efficiency, JSON for debugging)
+    - Add versioning so we don't break backwards compatibility
+
+### Phase 4: AST Implementation and Converter
+
+Now for the fun part - connecting our bytecode to the actual Rholang language:
+
+- Abstract Syntax Tree (AST) for Rholang
+    - Define AST node types for all Rholang constructs
+    - Implement a visitor pattern for easy AST traversal
+    - Track source locations for helpful error reporting
+- Tree-Sitter to AST Converter
+    - Build a converter from Tree-Sitter parse trees to our AST
+    - Handle all Rholang language constructs
+    - Add robust error recovery and reporting
+- AST to Bytecode Converter
+    - Create a compiler that transforms the AST to bytecode
+    - Implement code generation for all AST node types
+    - Add some basic optimizations at the AST level
+- Integration with Existing Components
+    - Update the shell to use our new bytecode compiler
+    - Modify the interpreter provider to execute bytecode
+    - Add command-line options to control compilation
+
+### Phase 5: Validation & Analysis
+
+We need to make sure our bytecode is correct and efficient:
+
+- Static Validation
+    - Add syntax and semantic validation checks
+    - Catch undefined names and variables early
+    - Validate type correctness where possible
+- Type Analysis
+    - Implement type inference and checking
+    - Add type annotations to the AST
+    - Use type information to enable optimizations
+- Optimization Analysis
+    - Find and eliminate dead code
+    - Identify and remove redundant operations
+    - Implement constant folding and propagation
+    - Add peephole optimizations for bytecode
+
+### Phase 6: Testing & Benchmarking
+
+Last but not least - making sure everything works:
+
+- Unit Tests
+    - Test individual components thoroughly (AST, bytecode, compiler)
+    - Cover edge cases and error handling
+- Integration Tests
+    - Test the complete compilation pipeline
+    - Verify with real Rholang programs
+    - Ensure interoperability with existing components
+- Benchmarks
+    - Measure compilation performance
+    - Compare different optimization levels
+    - Benchmark against our reference implementation
+- Documentation and Examples
+    - Document the bytecode format and instructions
+    - Provide examples of compiled Rholang programs
+    - Create tutorials for extending the compiler
+
+## Implementation Strategy
+
+We'll follow these principles throughout development:
+
+1. **Incremental Development**: Let's build in phases and get feedback early. No big-bang integration at the end!
+2. **Modular Design**: Components should be modular and reusable. We can swap parts out later.
+3. **Test-Driven Development**: Tests first (or at least alongside) implementation. This will save us headaches later.
+4. **Performance Focus**: Performance matters, especially for bytecode execution. Let's monitor it from the start.
+5. **Compatibility**: Our bytecode implementation should work with existing Rholang code. No breaking changes!
+
+## Grammar and Bytecode Instruction Compatibility
+
+Looking at our current Rholang grammar (in `grammar.js`), we've noticed several gaps between what the grammar supports and what our bytecode needs:
+
+1. **Stack Operations**: None of the stack operations (`Push`, `Pop`, `Dup`, etc.) are in the grammar yet. This makes sense since they're VM-specific operations rather than language constructs.
+
+2. **Control Flow Instructions**: The low-level control flow stuff (`Jump`, `JumpIf`, `Call`, etc.) isn't in the grammar, though higher-level constructs like `Match` exist.
+
+3. **Memory Instructions**: The grammar does not represent memory management instructions (`Load`, `Store`, etc.).
+
+4. **Data Structure Operations**: The grammar defines syntax for lists, maps, and tuples, but doesn't include the specific operations for manipulating them.
+
+5. **String Operations**: String manipulation instructions aren't explicitly in the grammar.
+
+We must bridge this gap by translating high-level Rholang constructs into appropriate low-level bytecode operations during compilation.
+
+## Future Work
+
+Once we've got the basics working, there's plenty more we could do:
+
+- Build a proper bytecode interpreter or VM
+- Add just-in-time (JIT) compilation for performance
+- Implement more advanced optimizations
+- Extend the bytecode to support new Rholang features
+- Update the grammar to better align with bytecode operations
+
+Let's focus on getting the core functionality solid first, then we can tackle these enhancements!

--- a/rholang-bytecode/Cargo.toml
+++ b/rholang-bytecode/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rholang-bytecode"
+version = "0.1.0"
+edition = "2021"
+description = "Bytecode representation and utilities for Rholang"
+
+[lib]
+name = "rholang_bytecode"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+# For bytecode serialization
+bincode = { workspace = true }
+# For error handling
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+proptest = "1.0"
+
+[[example]]
+name = "core_types_example"
+path = "examples/core_types_example.rs"

--- a/rholang-bytecode/examples/core_types_example.rs
+++ b/rholang-bytecode/examples/core_types_example.rs
@@ -1,0 +1,124 @@
+//! Example demonstrating the core types in rholang-bytecode
+//!
+//! This example shows how to use Value, ConstantPool, and Name types
+
+use rholang_bytecode::{
+    Value, ConstantPool, ChannelName, UnforgeableName,
+    VarRefKind, BundleValue, ContractValue
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Rholang Bytecode Core Types Example");
+    println!("===================================\n");
+
+    // Create a constant pool for managing constants
+    let mut pool = ConstantPool::new();
+
+    // Add various constants to the pool
+    let hello_idx = pool.add_string("Hello, Rholang!");
+    let answer_idx = pool.add_integer(42);
+    let truth_idx = pool.add_boolean(true);
+    let stdout_idx = pool.add_identifier("stdout");
+
+    println!("📊 Constant Pool:");
+    println!("  String constant: {} (index: {})",
+             pool.get_string(hello_idx)?, hello_idx.get());
+    println!("  Integer constant: {} (index: {})",
+             pool.get_integer(answer_idx)?, answer_idx.get());
+    println!("  Boolean constant: {} (index: {})",
+             pool.get_boolean(truth_idx)?, truth_idx.get());
+    println!("  Identifier: {} (index: {})",
+             pool.get_identifier(stdout_idx)?, stdout_idx.get());
+    println!("  Pool size: {} constants\n", pool.len());
+    
+    println!("🎯 Value Types:");
+
+    // Basic values
+    let int_val = Value::Int(100);
+    let str_val = Value::String("Rholang String".to_string());
+    let bool_val = Value::Bool(false);
+
+    println!("  Integer: {} (truthy: {})", int_val.as_int()?, int_val.is_truthy());
+    println!("  String: {:?} (truthy: {})", str_val, str_val.is_truthy());
+    println!("  Boolean: {} (truthy: {})", bool_val.as_bool()?, bool_val.is_truthy());
+
+    // Complex values
+    let list_val = Value::List(vec![
+        Value::Int(1),
+        Value::Int(2),
+        Value::Int(3)
+    ]);
+
+    let map_val = Value::Map(vec![
+        ("name".to_string(), Value::String("Alice".to_string())),
+        ("age".to_string(), Value::Int(30)),
+    ]);
+
+    println!("  List: {:?} (truthy: {})", list_val, list_val.is_truthy());
+    println!("  Map: {:?} (truthy: {})", map_val, map_val.is_truthy());
+
+    // Variable reference
+    let var_ref = Value::VarRef {
+        kind: VarRefKind::Standard,
+        name: "myVariable".to_string(),
+    };
+    println!("  Variable Reference: {:?}", var_ref);
+
+    // Unforgeable name
+    let unforgeable = UnforgeableName::generate();
+    let name_val = Value::Name(unforgeable.clone());
+    println!("  Unforgeable Name: {:?}", name_val);
+
+    // Bundle value
+    let bundle_val = Value::Bundle(BundleValue::Read(Box::new(Value::Int(123))));
+    println!("  Bundle: {:?}", bundle_val);
+
+    // Contract value
+    let contract_val = Value::Contract(ContractValue {
+        name: "MyContract".to_string(),
+        formals: vec!["input".to_string(), "return".to_string()],
+        body: "return!(input * 2)".to_string(),
+    });
+    println!("  Contract: {:?}\n", contract_val);
+
+    // Channel names
+    println!("🔗 Channel Names:");
+
+    let var_channel = ChannelName::from_variable("stdout");
+    let unforgeable_channel = ChannelName::from_unforgeable(unforgeable);
+    let wildcard_channel = ChannelName::wildcard();
+
+    println!("  Variable channel: {:?} (is_variable: {})",
+             var_channel, var_channel.is_variable());
+    println!("  Unforgeable channel: {:?} (is_unforgeable: {})",
+             unforgeable_channel, unforgeable_channel.is_unforgeable());
+    println!("  Wildcard channel: {:?} (is_wildcard: {})",
+             wildcard_channel, wildcard_channel.is_wildcard());
+
+    // Type information
+    println!("\n📋 Type Information:");
+    let values = vec![
+        Value::Nil,
+        Value::Bool(true),
+        Value::Int(42),
+        Value::String("test".to_string()),
+        Value::Wildcard,
+    ];
+
+    for value in values {
+        println!("  {} -> type: {}",
+                 match &value {
+                     Value::Nil => "Nil".to_string(),
+                     Value::Bool(b) => format!("Bool({})", b),
+                     Value::Int(i) => format!("Int({})", i),
+                     Value::String(s) => format!("String(\"{}\")", s),
+                     Value::Wildcard => "Wildcard".to_string(),
+                     _ => "Other".to_string(),
+                 },
+                 value.type_name()
+        );
+    }
+
+    println!("\n✅ Phase 1 Core Types working correctly");
+    Ok(())
+}

--- a/rholang-bytecode/src/constants/mod.rs
+++ b/rholang-bytecode/src/constants/mod.rs
@@ -1,0 +1,3 @@
+pub mod pool;
+
+pub use pool::ConstantPool;

--- a/rholang-bytecode/src/constants/pool.rs
+++ b/rholang-bytecode/src/constants/pool.rs
@@ -1,0 +1,287 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use crate::types::{Value, ConstantIndex};
+use crate::errors::{BytecodeError, BytecodeResult};
+
+/// Stores frequently used constants and provides index-based access
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstantPool {
+    /// Vector of constants (indexed access)
+    constants: Vec<ConstantEntry>,
+    /// Map for fast lookup of existing constants (deduplication)
+    lookup: HashMap<ConstantEntry, ConstantIndex>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ConstantEntry {
+    /// String literal constants
+    String(String),
+    /// Integer literal constants  
+    Integer(i64),
+    /// Boolean literal constants
+    Boolean(bool),
+    /// URI literal constants
+    Uri(String),
+    /// ByteArray literal constants
+    ByteArray(Vec<u8>),
+    /// Variable/identifier names
+    Identifier(String),
+    /// Contract names
+    ContractName(String),
+    /// Method names
+    MethodName(String),
+    /// Type names (Bool, Int, String, etc.)
+    TypeName(String),
+    /// Full Value constants (for complex literals)
+    Value(Value),
+}
+
+impl ConstantPool {
+    pub fn new() -> Self {
+        Self {
+            constants: Vec::new(),
+            lookup: HashMap::new(),
+        }
+    }
+    
+    pub fn add_constant(&mut self, entry: ConstantEntry) -> ConstantIndex {
+        if let Some(&index) = self.lookup.get(&entry) {
+            return index;
+        }
+        
+        let index = ConstantIndex::new(self.constants.len());
+        self.constants.push(entry.clone());
+        self.lookup.insert(entry, index);
+        index
+    }
+    
+    pub fn get_constant(&self, index: ConstantIndex) -> BytecodeResult<&ConstantEntry> {
+        self.constants.get(index.get()).ok_or_else(|| {
+            BytecodeError::IndexOutOfBounds {
+                index: index.get(),
+                max: self.constants.len(),
+            }
+        })
+    }
+    
+    pub fn len(&self) -> usize {
+        self.constants.len()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.constants.is_empty()
+    }
+
+    /// Helper methods for adding specific constant types
+    pub fn add_string(&mut self, s: impl Into<String>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::String(s.into()))
+    }
+    
+    pub fn add_integer(&mut self, i: i64) -> ConstantIndex {
+        self.add_constant(ConstantEntry::Integer(i))
+    }
+    
+    pub fn add_boolean(&mut self, b: bool) -> ConstantIndex {
+        self.add_constant(ConstantEntry::Boolean(b))
+    }
+    
+    pub fn add_uri(&mut self, uri: impl Into<String>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::Uri(uri.into()))
+    }
+    
+    pub fn add_byte_array(&mut self, bytes: Vec<u8>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::ByteArray(bytes))
+    }
+    
+    pub fn add_identifier(&mut self, name: impl Into<String>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::Identifier(name.into()))
+    }
+    
+    pub fn add_contract_name(&mut self, name: impl Into<String>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::ContractName(name.into()))
+    }
+    
+    pub fn add_method_name(&mut self, name: impl Into<String>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::MethodName(name.into()))
+    }
+    
+    pub fn add_type_name(&mut self, name: impl Into<String>) -> ConstantIndex {
+        self.add_constant(ConstantEntry::TypeName(name.into()))
+    }
+    
+    pub fn add_value(&mut self, value: Value) -> ConstantIndex {
+        self.add_constant(ConstantEntry::Value(value))
+    }
+
+    /// Helper methods for retrieving specific constant types
+    pub fn get_string(&self, index: ConstantIndex) -> BytecodeResult<&str> {
+        match self.get_constant(index)? {
+            ConstantEntry::String(s) => Ok(s),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected string constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn get_integer(&self, index: ConstantIndex) -> BytecodeResult<i64> {
+        match self.get_constant(index)? {
+            ConstantEntry::Integer(i) => Ok(*i),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected integer constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn get_boolean(&self, index: ConstantIndex) -> BytecodeResult<bool> {
+        match self.get_constant(index)? {
+            ConstantEntry::Boolean(b) => Ok(*b),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected boolean constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn get_uri(&self, index: ConstantIndex) -> BytecodeResult<&str> {
+        match self.get_constant(index)? {
+            ConstantEntry::Uri(uri) => Ok(uri),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected URI constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn get_byte_array(&self, index: ConstantIndex) -> BytecodeResult<&[u8]> {
+        match self.get_constant(index)? {
+            ConstantEntry::ByteArray(bytes) => Ok(bytes),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected byte array constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn get_identifier(&self, index: ConstantIndex) -> BytecodeResult<&str> {
+        match self.get_constant(index)? {
+            ConstantEntry::Identifier(name) => Ok(name),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected identifier constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn get_value(&self, index: ConstantIndex) -> BytecodeResult<&Value> {
+        match self.get_constant(index)? {
+            ConstantEntry::Value(value) => Ok(value),
+            entry => Err(BytecodeError::TypeError(
+                format!("Expected value constant, got {:?}", entry)
+            )),
+        }
+    }
+    
+    pub fn clear(&mut self) {
+        self.constants.clear();
+        self.lookup.clear();
+    }
+    
+    pub fn constants(&self) -> &[ConstantEntry] {
+        &self.constants
+    }
+}
+
+impl Default for ConstantPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConstantEntry {
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            ConstantEntry::String(_) => "String",
+            ConstantEntry::Integer(_) => "Integer",
+            ConstantEntry::Boolean(_) => "Boolean",
+            ConstantEntry::Uri(_) => "Uri",
+            ConstantEntry::ByteArray(_) => "ByteArray",
+            ConstantEntry::Identifier(_) => "Identifier",
+            ConstantEntry::ContractName(_) => "ContractName",
+            ConstantEntry::MethodName(_) => "MethodName",
+            ConstantEntry::TypeName(_) => "TypeName",
+            ConstantEntry::Value(_) => "Value",
+        }
+    }
+    
+    pub fn to_value(&self) -> Value {
+        match self {
+            ConstantEntry::String(s) => Value::String(s.clone()),
+            ConstantEntry::Integer(i) => Value::Int(*i),
+            ConstantEntry::Boolean(b) => Value::Bool(*b),
+            ConstantEntry::Uri(u) => Value::Uri(u.clone()),
+            ConstantEntry::ByteArray(b) => Value::ByteArray(b.clone()),
+            ConstantEntry::Identifier(name) => Value::VarRef {
+                kind: crate::types::VarRefKind::Standard,
+                name: name.clone(),
+            },
+            ConstantEntry::Value(v) => v.clone(),
+            ConstantEntry::ContractName(name) => Value::String(name.clone()),
+            ConstantEntry::MethodName(name) => Value::String(name.clone()),
+            ConstantEntry::TypeName(name) => Value::String(name.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_pool_basic_operations() {
+        let mut pool = ConstantPool::new();
+        
+        let str_idx = pool.add_string("hello");
+        let int_idx = pool.add_integer(42);
+        let bool_idx = pool.add_boolean(true);
+
+        assert_eq!(pool.len(), 3);
+        
+        assert_eq!(pool.get_string(str_idx).unwrap(), "hello");
+        assert_eq!(pool.get_integer(int_idx).unwrap(), 42);
+        assert_eq!(pool.get_boolean(bool_idx).unwrap(), true);
+    }
+
+    #[test]
+    fn test_constant_deduplication() {
+        let mut pool = ConstantPool::new();
+
+        // Add the same string twice
+        let idx1 = pool.add_string("hello");
+        let idx2 = pool.add_string("hello");
+
+        // Should get the same index
+        assert_eq!(idx1, idx2);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn test_constant_type_errors() {
+        let mut pool = ConstantPool::new();
+        let str_idx = pool.add_string("hello");
+        
+        assert!(pool.get_integer(str_idx).is_err());
+    }
+
+    #[test]
+    fn test_index_out_of_bounds() {
+        let pool = ConstantPool::new();
+        let invalid_idx = ConstantIndex::new(999);
+
+        assert!(pool.get_constant(invalid_idx).is_err());
+    }
+
+    #[test]
+    fn test_constant_entry_to_value() {
+        let entry = ConstantEntry::String("test".to_string());
+        let value = entry.to_value();
+
+        assert_eq!(value, Value::String("test".to_string()));
+        assert_eq!(entry.type_name(), "String");
+    }
+}

--- a/rholang-bytecode/src/errors/errors.rs
+++ b/rholang-bytecode/src/errors/errors.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+/// Main error types for bytecode operations
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum BytecodeError {
+    #[error("Invalid instruction: {0}")]
+    InvalidInstruction(String),
+
+    #[error("Constant pool error: {0}")]
+    ConstantPool(String),
+
+    #[error("Type error: {0}")]
+    TypeError(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("Index out of bounds: {index} >= {max}")]
+    IndexOutOfBounds { index: usize, max: usize },
+
+    #[error("Other error: {0}")]
+    Other(String),
+}
+
+pub type BytecodeResult<T> = Result<T, BytecodeError>;

--- a/rholang-bytecode/src/errors/mod.rs
+++ b/rholang-bytecode/src/errors/mod.rs
@@ -1,0 +1,3 @@
+pub mod errors;
+
+pub use errors::*;

--- a/rholang-bytecode/src/lib.rs
+++ b/rholang-bytecode/src/lib.rs
@@ -1,0 +1,19 @@
+//! Rholang Bytecode Library
+pub mod types;
+pub mod constants;
+pub mod errors;
+
+pub use types::*;
+pub use constants::ConstantPool;
+pub use errors::BytecodeError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_setup() {
+        // Basic test to ensure the module compiles
+        assert!(true);
+    }
+}

--- a/rholang-bytecode/src/types/address.rs
+++ b/rholang-bytecode/src/types/address.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+/// Index into the constant pool
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ConstantIndex(pub usize);
+
+/// Index for local variables (used in Match/MatchCase patterns)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LocalIndex(pub usize);
+
+/// Offset for bytecode jumps (used internally by Match/MatchCase)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BytecodeOffset(pub isize);
+
+impl ConstantIndex {
+    pub fn new(index: usize) -> Self {
+        Self(index)
+    }
+    
+    pub fn get(&self) -> usize {
+        self.0
+    }
+}
+
+impl LocalIndex {
+    pub fn new(index: usize) -> Self {
+        Self(index)
+    }
+    
+    pub fn get(&self) -> usize {
+        self.0
+    }
+}
+
+impl BytecodeOffset {
+    pub fn new(offset: isize) -> Self {
+        Self(offset)
+    }
+    
+    pub fn get(&self) -> isize {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_index() {
+        let index = ConstantIndex::new(42);
+        assert_eq!(index.get(), 42);
+    }
+
+    #[test]
+    fn test_local_index() {
+        let index = LocalIndex::new(10);
+        assert_eq!(index.get(), 10);
+    }
+
+    #[test]
+    fn test_bytecode_offset() {
+        let offset = BytecodeOffset::new(-5);
+        assert_eq!(offset.get(), -5);
+    }
+}

--- a/rholang-bytecode/src/types/mod.rs
+++ b/rholang-bytecode/src/types/mod.rs
@@ -1,0 +1,7 @@
+pub mod value;
+pub mod address;
+pub mod name;
+
+pub use value::*;
+pub use address::*;
+pub use name::*;

--- a/rholang-bytecode/src/types/name.rs
+++ b/rholang-bytecode/src/types/name.rs
@@ -1,0 +1,177 @@
+use serde::{Deserialize, Serialize};
+use crate::types::{UnforgeableName, Value};
+
+/// Channel name for Send/Receive operations
+/// Grammar: name: $ => choice($._proc_var, $.quote)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ChannelName {
+    /// Unforgeable channel name (from New instruction)
+    Unforgeable(UnforgeableName),
+    /// Variable reference to a channel (var from grammar)
+    Variable(String),
+    /// Wildcard channel name ('_' from grammar)
+    Wildcard,
+    /// Quoted process as channel name ('@' prefix from grammar)
+    Quote(Value),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProcessId {
+    pub id: String,
+}
+
+/// Source types for input operations
+/// Grammar: _source: $ => choice($.simple_source, $.receive_send_source, $.send_receive_source)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SourceName {
+    /// Simple source: just a name
+    Simple(ChannelName),
+    /// Receive-send source: name with '?!' operator
+    ReceiveSend(ChannelName),
+    /// Send-receive source: name with '!?' operator and inputs
+    SendReceive {
+        name: ChannelName,
+        inputs: Vec<Value>
+    },
+}
+
+impl ChannelName {
+    pub fn from_unforgeable(name: UnforgeableName) -> Self {
+        Self::Unforgeable(name)
+    }
+    
+    pub fn from_variable(name: impl Into<String>) -> Self {
+        Self::Variable(name.into())
+    }
+    
+    pub fn wildcard() -> Self {
+        Self::Wildcard
+    }
+    
+    pub fn from_quote(value: Value) -> Self {
+        Self::Quote(value)
+    }
+    
+    pub fn is_unforgeable(&self) -> bool {
+        matches!(self, Self::Unforgeable(_))
+    }
+    
+    pub fn is_variable(&self) -> bool {
+        matches!(self, Self::Variable(_))
+    }
+    
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, Self::Wildcard)
+    }
+    
+    pub fn is_quote(&self) -> bool {
+        matches!(self, Self::Quote(_))
+    }
+    
+    pub fn as_variable(&self) -> Option<&str> {
+        match self {
+            Self::Variable(name) => Some(name),
+            _ => None,
+        }
+    }
+}
+
+impl ProcessId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+    
+    pub fn generate() -> Self {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let mut hasher = DefaultHasher::new();
+        SystemTime::now().duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+            .hash(&mut hasher);
+
+        let hash = hasher.finish();
+        Self::new(format!("proc_{:x}", hash))
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.id
+    }
+}
+
+impl SourceName {
+    pub fn simple(name: ChannelName) -> Self {
+        Self::Simple(name)
+    }
+    
+    pub fn receive_send(name: ChannelName) -> Self {
+        Self::ReceiveSend(name)
+    }
+    
+    pub fn send_receive(name: ChannelName, inputs: Vec<Value>) -> Self {
+        Self::SendReceive { name, inputs }
+    }
+    
+    pub fn channel_name(&self) -> &ChannelName {
+        match self {
+            Self::Simple(name) => name,
+            Self::ReceiveSend(name) => name,
+            Self::SendReceive { name, .. } => name,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_channel_name_from_variable() {
+        let channel = ChannelName::from_variable("stdout");
+        assert!(channel.is_variable());
+        assert!(!channel.is_unforgeable());
+        assert_eq!(channel.as_variable(), Some("stdout"));
+    }
+
+    #[test]
+    fn test_channel_name_from_unforgeable() {
+        let unforgeable = UnforgeableName::generate();
+        let channel = ChannelName::from_unforgeable(unforgeable.clone());
+        assert!(channel.is_unforgeable());
+        assert!(!channel.is_variable());
+        assert_eq!(channel, ChannelName::Unforgeable(unforgeable));
+    }
+
+    #[test]
+    fn test_channel_name_wildcard() {
+        let channel = ChannelName::wildcard();
+        assert!(channel.is_wildcard());
+        assert!(!channel.is_variable());
+        assert!(!channel.is_unforgeable());
+    }
+
+    #[test]
+    fn test_process_id_generation() {
+        let proc1 = ProcessId::generate();
+        let proc2 = ProcessId::generate();
+        assert_ne!(proc1.id, proc2.id);
+        assert!(proc1.id.starts_with("proc_"));
+        assert!(proc1.as_str().starts_with("proc_"));
+    }
+
+    #[test]
+    fn test_source_name_types() {
+        let channel = ChannelName::from_variable("test");
+
+        let simple = SourceName::simple(channel.clone());
+        assert_eq!(simple.channel_name(), &channel);
+
+        let recv_send = SourceName::receive_send(channel.clone());
+        assert_eq!(recv_send.channel_name(), &channel);
+
+        let send_recv = SourceName::send_receive(channel.clone(), vec![]);
+        assert_eq!(send_recv.channel_name(), &channel);
+    }
+}

--- a/rholang-bytecode/src/types/value.rs
+++ b/rholang-bytecode/src/types/value.rs
@@ -1,0 +1,173 @@
+use serde::{Deserialize, Serialize};
+use crate::errors::{BytecodeError, BytecodeResult};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Value {
+    /// Unit/Nil value
+    Nil,
+    /// Boolean values
+    Bool(bool),
+    /// Integer values
+    Int(i64),
+    /// String values (literals in grammar)
+    String(String),
+    /// URI values (literals in grammar)
+    Uri(String),
+    /// ByteArray values (simple_type in grammar)
+    ByteArray(Vec<u8>),
+    /// Wildcard value ('_' in grammar)
+    Wildcard,
+    /// Variable reference (var_ref in grammar)
+    VarRef { kind: VarRefKind, name: String },
+    /// Unforgeable names (from New instruction)
+    Name(UnforgeableName),
+    /// Quoted processes
+    Quote(QuotedValue),
+    /// List values
+    List(Vec<Value>),
+    /// Tuple values
+    Tuple(Vec<Value>),
+    /// Set values
+    Set(Vec<Value>),
+    /// Map values
+    Map(Vec<(String, Value)>),
+    /// Bundle values
+    Bundle(BundleValue),
+    /// Contract values
+    Contract(ContractValue),
+}
+
+/// Unforgeable names in Rholang (from New instruction)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UnforgeableName {
+    pub id: Vec<u8>,
+}
+
+/// Quoted values for Rholang quoting
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum QuotedValue {
+    Process(String),
+    Name(UnforgeableName),
+}
+
+/// Bundle types
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum BundleValue {
+    Read(Box<Value>),
+    Write(Box<Value>),
+    Equiv(Box<Value>),
+    ReadWrite(Box<Value>),
+}
+
+/// Contract definition
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ContractValue {
+    pub name: String,
+    pub formals: Vec<String>,
+    pub body: String,
+}
+
+/// Variable reference kinds
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum VarRefKind {
+    Standard,    // '='
+    Wildcard,    // '=*'
+}
+
+impl Value {
+    pub fn is_truthy(&self) -> bool {
+        match self {
+            Value::Bool(b) => *b,
+            Value::Int(i) => *i != 0,
+            Value::Nil | Value::Wildcard => false,
+            Value::List(l) | Value::Tuple(l) | Value::Set(l) => !l.is_empty(),
+            Value::Map(m) => !m.is_empty(),
+            Value::String(s) | Value::Uri(s) => !s.is_empty(),
+            Value::ByteArray(b) => !b.is_empty(),
+            _ => true,
+        }
+    }
+    
+    pub fn as_int(&self) -> BytecodeResult<i64> {
+        match self {
+            Value::Int(i) => Ok(*i),
+            _ => Err(BytecodeError::TypeError(
+                format!("Cannot convert {} to integer", self.type_name())
+            )),
+        }
+    }
+    
+    pub fn as_bool(&self) -> BytecodeResult<bool> {
+        match self {
+            Value::Bool(b) => Ok(*b),
+            _ => Err(BytecodeError::TypeError(
+                format!("Cannot convert {} to boolean", self.type_name())
+            )),
+        }
+    }
+    
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Value::Nil => "Nil",
+            Value::Bool(_) => "Bool",
+            Value::Int(_) => "Int",
+            Value::String(_) => "String",
+            Value::Uri(_) => "Uri",
+            Value::ByteArray(_) => "ByteArray",
+            Value::Wildcard => "Wildcard",
+            Value::VarRef { .. } => "VarRef",
+            Value::Name(_) => "Name",
+            Value::Quote(_) => "Quote",
+            Value::List(_) => "List",
+            Value::Tuple(_) => "Tuple",
+            Value::Set(_) => "Set",
+            Value::Map(_) => "Map",
+            Value::Bundle(_) => "Bundle",
+            Value::Contract(_) => "Contract",
+        }
+    }
+}
+
+impl UnforgeableName {
+    pub fn new(id: Vec<u8>) -> Self {
+        Self { id }
+    }
+
+    pub fn generate() -> Self {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        Self::new(timestamp.to_be_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_value_creation_and_types() {
+        assert_eq!(Value::Int(42).type_name(), "Int");
+        assert_eq!(Value::Bool(true).type_name(), "Bool");
+        assert_eq!(Value::String("test".to_string()).type_name(), "String");
+        assert_eq!(Value::Nil.type_name(), "Nil");
+    }
+
+    #[test]
+    fn test_truthiness() {
+        assert!(Value::Bool(true).is_truthy());
+        assert!(!Value::Bool(false).is_truthy());
+        assert!(Value::Int(1).is_truthy());
+        assert!(!Value::Int(0).is_truthy());
+        assert!(!Value::Nil.is_truthy());
+    }
+
+    #[test]
+    fn test_unforgeable_name_generation() {
+        let name1 = UnforgeableName::generate();
+        let name2 = UnforgeableName::generate();
+        assert_ne!(name1.id, name2.id);
+    }
+}


### PR DESCRIPTION
That PR adds `rholang-bytecode` crate and it's **Phase 1** implementation. For now only those bytecode instructions that are in grammar have been added.

### Point for discussion:

In `pub enum Value` we have `Set(Vec<Value>)` and `Map(Vec<(String, Value)>)` values. I've now set them as `Vec`, for simplicity, but that may not be the best solution. And maybe it would be better to use `HashMap` and `HashSet` for this? This may increase the size and complexity of the `value.rs` file, but it will be critical if the size of these collections will be large.
The question is, do we keep the simple `Vec` option or develop an approach with `HashMap` and `HashSet` right away?

