### PR TITLE
Create benchmarks for parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,11 @@ docker-compose.override.yml
 
 # Unreviewed insta snapshots
 *.snap.new
+
+# Perf data and flamegraphs
+flamegraph.svg
+perf.data
+perf.data.old
+
+# Local cargo config
+.cargo/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ async-std = { version = "1.13.1", features = ["attributes"] }
 # Used by: shell
 bracket-parser = "0.1.0"
 
+# Library for benchmarking
+divan = "0.1.21"
+
 # Used by: rholang-parser
 smallvec = { version = "1.15.1", features = ["union", "const_generics", "const_new", "may_dangle"] }
 
@@ -64,3 +67,6 @@ is-terminal = "0.4.12"
 
 [profile.dev]
 debug = true
+
+[profile.bench]
+debug = "line-tables-only"

--- a/rholang-parser/Cargo.toml
+++ b/rholang-parser/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2024"
 name = "rholang_parser"
 crate-type = ["cdylib", "rlib"]
 
+[[bench]]
+name = "parsing"
+harness = false
+
 [dependencies]
 bitvec = { workspace = true }
 nonempty-collections = "1.0.0"
@@ -19,5 +23,6 @@ typed-arena = "2.0.2"
 validated = { workspace = true }
 
 [dev-dependencies]
+divan = { workspace = true }
 insta = "1.43.1"
 rstest = { workspace = true }

--- a/rholang-parser/benches/parsing.rs
+++ b/rholang-parser/benches/parsing.rs
@@ -1,0 +1,27 @@
+use std::{fs, path::PathBuf};
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench(args = each_corpus_file())]
+fn parsing(arg: &PathBuf) {
+    let code = fs::read_to_string(arg).expect("expected a readable file");
+    let parser = rholang_parser::RholangParser::new();
+    let result = parser.parse(&code);
+    divan::black_box_drop(result);
+}
+
+fn each_corpus_file() -> impl Iterator<Item = PathBuf> {
+    fs::read_dir("tests/corpus")
+        .expect("expected tests/corpus directory to exist")
+        .map(|dir_entry_or_error| dir_entry_or_error.unwrap())
+        .filter_map(|dir_entry| {
+            let path = dir_entry.path();
+            if path.is_file() && path.extension().is_some_and(|ext| ext == "rho") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+}

--- a/rholang-parser/benches/parsing.rs
+++ b/rholang-parser/benches/parsing.rs
@@ -5,11 +5,13 @@ fn main() {
 }
 
 #[divan::bench(args = each_corpus_file())]
-fn parsing(arg: &PathBuf) {
+fn parsing(bencher: divan::Bencher, arg: &PathBuf) {
     let code = fs::read_to_string(arg).expect("expected a readable file");
-    let parser = rholang_parser::RholangParser::new();
-    let result = parser.parse(&code);
-    divan::black_box_drop(result);
+    bencher.bench_local(|| {
+        let parser = rholang_parser::RholangParser::new();
+        let result = parser.parse(&code);
+        divan::black_box_drop(result);
+    });
 }
 
 fn each_corpus_file() -> impl Iterator<Item = PathBuf> {

--- a/rholang-parser/src/parser/parsing.rs
+++ b/rholang-parser/src/parser/parsing.rs
@@ -395,7 +395,7 @@ pub(super) fn node_to_ast<'ast>(
                             };
                             let name_count = names_node.map_or(0, |n| n.named_child_count());
                             let cont_present = names_node
-                                .map_or(false, |n| n.child_by_field_id(field!("cont")).is_some());
+                                .is_some_and(|n| n.child_by_field_id(field!("cont")).is_some());
 
                             let bind_desc = match bind_node.kind_id() {
                                 kind!("linear_bind") => {
@@ -661,7 +661,7 @@ fn query_errors(of: &tree_sitter::Node, source: &str, into: &mut Vec<AnnParsingE
             if error_node.is_missing() {
                 into.push(AnnParsingError::from_mising(&error_node));
             } else {
-                if error_node.parent().map_or(false, |p| p.is_error()) {
+                if error_node.parent().is_some_and(|p| p.is_error()) {
                     // if parent of this node is an error, we skip it because it is UNEXPECTED node which we process somewhere else
                     continue;
                 }
@@ -1285,6 +1285,7 @@ impl Debug for ProcStack<'_> {
     }
 }
 
+#[inline]
 fn get_first_child<'a>(of: &tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
     of.named_child(0).unwrap_or_else(|| {
         panic!(
@@ -1309,6 +1310,7 @@ fn get_left_and_right<'a>(
         })
 }
 
+#[inline]
 fn get_field<'a>(of: &tree_sitter::Node<'a>, id: u16) -> tree_sitter::Node<'a> {
     of.child_by_field_id(id).unwrap_or_else(|| {
         let rholang_language: tree_sitter::Language = rholang_tree_sitter::LANGUAGE.into();


### PR DESCRIPTION
I thought it'd be a nice idea to have a benchmark suite for the parser (and other components). So I did a quick experiment on how to do it.
I used a library called [Divan](https://docs.rs/divan/latest/divan/index.html) because it was very easy to set up.

### Running

You can run the benchmarks like this:

```
> cargo bench parsing
```

from the project directory.

The results:

```
Timer precision: 18 ns
parsing                                              fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ parsing                                                         │               │               │               │         │
├─ "tests/corpus/1.know_ones_revaddress.rho"      29.44 µs      │ 103.6 µs      │ 32.15 µs      │ 32.77 µs      │ 100     │ 100
├─ "tests/corpus/2.check_balance.rho"             53.19 µs      │ 76.21 µs      │ 57.9 µs       │ 57.92 µs      │ 100     │ 100
├─ "tests/corpus/3.transfer_funds.rho"            90.66 µs      │ 130.2 µs      │ 98.58 µs      │ 98.44 µs      │ 100     │ 100
├─ "tests/corpus/Cell1.rho"                       32.21 µs      │ 47.97 µs      │ 34.36 µs      │ 34.88 µs      │ 100     │ 100
├─ "tests/corpus/Cell3.rho"                       474.8 µs      │ 834.6 µs      │ 496.5 µs      │ 502 µs        │ 100     │ 100
├─ "tests/corpus/ListProcTest.rho"                12.35 µs      │ 23.67 µs      │ 12.64 µs      │ 12.99 µs      │ 100     │ 100
├─ "tests/corpus/MethodTest.rho"                  25.72 µs      │ 35.32 µs      │ 26.11 µs      │ 26.61 µs      │ 100     │ 100
├─ "tests/corpus/bank_contract.rho"               196.1 µs      │ 263.4 µs      │ 202.8 µs      │ 204.6 µs      │ 100     │ 100
├─ "tests/corpus/block-data.rho"                  27.33 µs      │ 39.67 µs      │ 27.9 µs       │ 28.42 µs      │ 100     │ 100
├─ "tests/corpus/bond.rho"                        37.32 µs      │ 49.76 µs      │ 38.9 µs       │ 39.28 µs      │ 100     │ 100
├─ "tests/corpus/coat_check.rho"                  127 µs        │ 147.4 µs      │ 129.6 µs      │ 131.4 µs      │ 100     │ 100
├─ "tests/corpus/dining_philosophers.rho"         40.22 µs      │ 58.36 µs      │ 41.91 µs      │ 42.87 µs      │ 100     │ 100
├─ "tests/corpus/dupe.rho"                        46.07 µs      │ 57.27 µs      │ 48.3 µs       │ 48.94 µs      │ 100     │ 100
├─ "tests/corpus/fileinteract.rho"                64.16 µs      │ 84.16 µs      │ 65.85 µs      │ 66.7 µs       │ 100     │ 100
├─ "tests/corpus/filestore.rho"                   465.8 µs      │ 579.3 µs      │ 485.9 µs      │ 488.2 µs      │ 100     │ 100
├─ "tests/corpus/for_patterns.rho"                79.18 µs      │ 100 µs        │ 81.71 µs      │ 82.71 µs      │ 100     │ 100
├─ "tests/corpus/fuseMap.rho"                     445.7 µs      │ 504.7 µs      │ 463.5 µs      │ 465.2 µs      │ 100     │ 100
├─ "tests/corpus/fuseRead.rho"                    32.36 µs      │ 48.22 µs      │ 33.12 µs      │ 33.63 µs      │ 100     │ 100
├─ "tests/corpus/fuseWrite.rho"                   93.21 µs      │ 123.3 µs      │ 96.68 µs      │ 97.24 µs      │ 100     │ 100
├─ "tests/corpus/hello_world_again.rho"           27.58 µs      │ 35.69 µs      │ 28.23 µs      │ 28.52 µs      │ 100     │ 100
├─ "tests/corpus/iteration.rho"                   51.36 µs      │ 70.51 µs      │ 52.36 µs      │ 53.5 µs       │ 100     │ 100
├─ "tests/corpus/longfast.rho"                    220.6 µs      │ 264.4 µs      │ 242.6 µs      │ 241.2 µs      │ 100     │ 100
├─ "tests/corpus/longslow.rho"                    238.6 µs      │ 284.5 µs      │ 257.7 µs      │ 258.1 µs      │ 100     │ 100
├─ "tests/corpus/loopback.rho"                    20.74 µs      │ 27.25 µs      │ 21.12 µs      │ 21.28 µs      │ 100     │ 100
├─ "tests/corpus/sending_receiving_multiple.rho"  53.33 µs      │ 73.1 µs       │ 55.25 µs      │ 55.84 µs      │ 100     │ 100
├─ "tests/corpus/shortfast.rho"                   5.959 µs      │ 9.489 µs      │ 6.285 µs      │ 6.417 µs      │ 100     │ 100
├─ "tests/corpus/shortslow.rho"                   16.8 µs       │ 24.53 µs      │ 17.21 µs      │ 17.43 µs      │ 100     │ 100
├─ "tests/corpus/simpleInsertCall.rho"            10.12 µs      │ 14.63 µs      │ 10.42 µs      │ 10.55 µs      │ 100     │ 100
├─ "tests/corpus/simpleInsertTest.rho"            57.44 µs      │ 74.02 µs      │ 59.23 µs      │ 59.77 µs      │ 100     │ 100
├─ "tests/corpus/simpleLookupTest.rho"            32.33 µs      │ 39.37 µs      │ 33.15 µs      │ 33.73 µs      │ 100     │ 100
├─ "tests/corpus/stderr.rho"                      6.395 µs      │ 9.791 µs      │ 6.675 µs      │ 6.82 µs       │ 100     │ 100
├─ "tests/corpus/stderrAck.rho"                   14.79 µs      │ 18.97 µs      │ 15.14 µs      │ 15.23 µs      │ 100     │ 100
├─ "tests/corpus/stdout.rho"                      6.395 µs      │ 10.51 µs      │ 6.734 µs      │ 6.852 µs      │ 100     │ 100
├─ "tests/corpus/stdoutAck.rho"                   15.05 µs      │ 18.65 µs      │ 15.49 µs      │ 15.63 µs      │ 100     │ 100
├─ "tests/corpus/treasury.rho"                    219.5 µs      │ 269.2 µs      │ 228.2 µs      │ 229.3 µs      │ 100     │ 100
├─ "tests/corpus/tut-bytearray-methods.rho"       21.77 µs      │ 35.41 µs      │ 22.13 µs      │ 22.45 µs      │ 100     │ 100
├─ "tests/corpus/tut-hash-functions.rho"          32.12 µs      │ 43.88 µs      │ 33.04 µs      │ 33.44 µs      │ 100     │ 100
├─ "tests/corpus/tut-hello-again.rho"             33.56 µs      │ 69.44 µs      │ 34.53 µs      │ 35.15 µs      │ 100     │ 100
├─ "tests/corpus/tut-hello.rho"                   29.36 µs      │ 34.78 µs      │ 30.84 µs      │ 30.91 µs      │ 100     │ 100
├─ "tests/corpus/tut-lists-methods.rho"           38.95 µs      │ 50.81 µs      │ 40.9 µs       │ 41.23 µs      │ 100     │ 100
├─ "tests/corpus/tut-maps-methods.rho"            151.2 µs      │ 176.3 µs      │ 157.6 µs      │ 158.3 µs      │ 100     │ 100
├─ "tests/corpus/tut-parens.rho"                  24.8 µs       │ 35.64 µs      │ 25.62 µs      │ 26.3 µs       │ 100     │ 100
├─ "tests/corpus/tut-philosophers.rho"            105.8 µs      │ 137.8 µs      │ 108.3 µs      │ 109.2 µs      │ 100     │ 100
├─ "tests/corpus/tut-prime.rho"                   59.95 µs      │ 85.08 µs      │ 61.37 µs      │ 62.59 µs      │ 100     │ 100
├─ "tests/corpus/tut-rcon-or.rho"                 36.29 µs      │ 48.72 µs      │ 37.41 µs      │ 37.88 µs      │ 100     │ 100
├─ "tests/corpus/tut-rcon.rho"                    44.75 µs      │ 58.02 µs      │ 46.35 µs      │ 46.94 µs      │ 100     │ 100
├─ "tests/corpus/tut-registry-split2.rho"         45.75 µs      │ 68.9 µs       │ 47.67 µs      │ 48.79 µs      │ 100     │ 100
├─ "tests/corpus/tut-registry.rho"                107.4 µs      │ 122.1 µs      │ 110.8 µs      │ 111.2 µs      │ 100     │ 100
├─ "tests/corpus/tut-sets-methods.rho"            128.1 µs      │ 151.1 µs      │ 132.4 µs      │ 132.9 µs      │ 100     │ 100
├─ "tests/corpus/tut-strings-methods.rho"         24.4 µs       │ 34.66 µs      │ 25 µs         │ 25.46 µs      │ 100     │ 100
╰─ "tests/corpus/tut-tuples-methods.rho"          17.31 µs      │ 22.86 µs      │ 17.66 µs      │ 17.93 µs      │ 100     │ 100
```

**Conclusion: it is fast :-)**

### Profiling

To profile the code I recommend the following setup:

1. create `.cargo/config.toml` file with the following contents:
```
[build]
rustflags = ["-C", "symbol-mangling-version=v0", "-C", "force-frame-pointers=yes"]
```

2. install `flamegraph` for Rust (`cargo install flamegraph`) - you also need to have `perf` installed if you are on Linux
3. run
```
> cargo flamegraph --bench parsing -- --bench --sample-count=4000
```
4. profit 

<img width="1920" height="995" alt="image" src="https://github.com/user-attachments/assets/49e91445-29f5-4178-a99a-c016256596b4" />
