### PR TITLE
Re-work error detection

### DIFF
--- a/rholang-parser/src/ast.rs
+++ b/rholang-parser/src/ast.rs
@@ -185,7 +185,7 @@ impl<'a> TryFrom<&Proc<'a>> for Name<'a> {
     fn try_from(value: &Proc<'a>) -> Result<Self, Self::Error> {
         match value {
             Proc::ProcVar(var) => Ok(Name::ProcVar(*var)),
-            Proc::Quote { proc } => Ok(Name::Quote(*proc)),
+            Proc::Quote { proc } => Ok(Name::Quote(proc)),
             Proc::Bad => Ok(Name::ProcVar(Var::Wildcard)), //helps with error recovery
             other => Err(format!("{{ {other:?} }} is not a name")),
         }

--- a/rholang-parser/src/parser/errors.rs
+++ b/rholang-parser/src/parser/errors.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashSet, ops::Range, sync::OnceLock};
+
 use nonempty_collections::NEVec;
 
 use crate::{SourcePos, SourceSpan, ast::AnnProc};
@@ -7,6 +9,7 @@ pub enum ParsingError {
     SyntaxError { sexp: String },
     MissingToken(&'static str),
     Unexpected(char),
+    UnexpectedVar(String),
     NumberOutOfRange,
     DuplicateNameDecl { first: SourcePos, second: SourcePos },
     MalformedLetDecl { lhs_arity: usize, rhs_arity: usize },
@@ -16,17 +19,12 @@ impl ParsingError {
     fn from_error_node(node: &tree_sitter::Node, code: &[u8]) -> Self {
         if let Some(child) = node.named_child(0) {
             if child.is_error() {
-                unsafe {
-                    // SAFETY: source code is expected to contain valid utf8 and our grammar does not allow to
-                    // chop any single character. So, byte ranges of all nodes must start and end on valid UTF-8
-                    // slice
-                    let text = str::from_utf8_unchecked(&code[child.byte_range()]);
-                    let mut chars = text.chars();
-                    if let Some(unexpected) = chars.next() {
-                        // it's a single char
-                        if chars.next().is_none() {
-                            return ParsingError::Unexpected(unexpected);
-                        }
+                let text = get_text(&child, code);
+                let mut chars = text.chars();
+                if let Some(unexpected) = chars.next() {
+                    // it's a single char
+                    if chars.next().is_none() {
+                        return ParsingError::Unexpected(unexpected);
                     }
                 }
             }
@@ -59,10 +57,90 @@ impl AnnParsingError {
             span: node.range().into(),
         }
     }
+
+    pub(super) fn from_var(var_node: &tree_sitter::Node, code: &[u8]) -> Self {
+        let var = get_text(var_node, code);
+        AnnParsingError {
+            error: ParsingError::UnexpectedVar(var.to_owned()),
+            span: var_node.range().into(),
+        }
+    }
+}
+
+fn get_text<'a>(of: &tree_sitter::Node, code: &'a [u8]) -> &'a str {
+    unsafe {
+        // SAFETY: source code is expected to contain valid utf8 and our grammar does not allow to
+        // chop any single character. So, byte ranges of all nodes must start and end on valid UTF-8
+        // slice
+        str::from_utf8_unchecked(&code[of.byte_range()])
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsingFailure<'a> {
     pub partial_tree: Option<AnnProc<'a>>,
     pub errors: NEVec<AnnParsingError>,
+}
+
+pub(super) fn query_errors(of: &tree_sitter::Node, source: &str, into: &mut Vec<AnnParsingError>) {
+    use tree_sitter::StreamingIterator;
+
+    static QUERY: OnceLock<tree_sitter::Query> = OnceLock::new();
+
+    let query = QUERY.get_or_init(|| {
+        let rholang_language = rholang_tree_sitter::LANGUAGE.into();
+        tree_sitter::Query::new(
+            &rholang_language,
+            "(ERROR (var) @error-var)
+            (MISSING) @missing-node 
+            (ERROR) @fallback",
+        )
+        .expect("failed to compile error query")
+    });
+
+    let mut cursor = tree_sitter::QueryCursor::new();
+    let source_bytes = source.as_bytes();
+
+    // Record parent ranges of specific errors like @error-var
+    let mut claimed_error_ranges: HashSet<Range<usize>> = HashSet::new();
+
+    // Temporarily hold general error nodes
+    let mut general_errors: Vec<tree_sitter::Node> = Vec::new();
+
+    let mut matches = cursor.matches(query, *of, source_bytes);
+    while let Some(m) = matches.next() {
+        for capture in m.captures {
+            let node = capture.node;
+
+            match capture.index {
+                0 => {
+                    // @error-var
+                    if let Some(parent) = node.parent() {
+                        claimed_error_ranges.insert(parent.byte_range());
+                    }
+                    into.push(AnnParsingError::from_var(&node, source_bytes));
+                }
+                1 => {
+                    // @missing-node
+                    into.push(AnnParsingError::from_mising(&node));
+                }
+                _ => {
+                    if node.parent().is_some_and(|p| p.is_error()) {
+                        continue; // skip UNEXPECTED, we process it somewhere else
+                    }
+                    general_errors.push(node);
+                }
+            }
+        }
+    }
+
+    // Emit only general errors not already claimed by more specific ones
+    for node in general_errors {
+        let range = node.byte_range();
+        if claimed_error_ranges.contains(&range) {
+            continue; // already handled by more specific pattern
+        }
+
+        into.push(AnnParsingError::from_error(&node, source_bytes));
+    }
 }

--- a/rholang-parser/src/parser/errors.rs
+++ b/rholang-parser/src/parser/errors.rs
@@ -29,15 +29,15 @@ pub enum ParsingError {
 
 impl ParsingError {
     fn from_error_node(node: &tree_sitter::Node, code: &[u8]) -> Self {
-        if let Some(child) = node.named_child(0) {
-            if child.is_error() {
-                let text = get_text(&child, code);
-                let mut chars = text.chars();
-                if let Some(unexpected) = chars.next() {
-                    // it's a single char
-                    if chars.next().is_none() {
-                        return ParsingError::Unexpected(unexpected);
-                    }
+        if let Some(child) = node.named_child(0)
+            && child.is_error()
+        {
+            let text = get_text(&child, code);
+            let mut chars = text.chars();
+            if let Some(unexpected) = chars.next() {
+                // it's a single char
+                if chars.next().is_none() {
+                    return ParsingError::Unexpected(unexpected);
                 }
             }
         }

--- a/rholang-parser/src/parser/mod.rs
+++ b/rholang-parser/src/parser/mod.rs
@@ -33,3 +33,9 @@ impl<'a> RholangParser<'a> {
             .collect()
     }
 }
+
+impl Default for RholangParser<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rholang-parser/src/parser/parsing.rs
+++ b/rholang-parser/src/parser/parsing.rs
@@ -116,10 +116,8 @@ pub(super) fn node_to_ast<'ast>(
                         }
                         Err(_) => {
                             // the only possibility is pos/neg overflow
-                            errors.push(AnnParsingError {
-                                error: ParsingError::NumberOutOfRange,
-                                span,
-                            });
+                            errors
+                                .push(AnnParsingError::new(ParsingError::NumberOutOfRange, &node));
                             bad = true;
                         }
                     }
@@ -347,10 +345,10 @@ pub(super) fn node_to_ast<'ast>(
                     let mut decls = parse_decls(&decls_node, source);
                     decls.sort_unstable();
                     if let Some((first, second)) = check_for_duplicate_decls(&decls) {
-                        errors.push(AnnParsingError {
-                            error: ParsingError::DuplicateNameDecl { first, second },
-                            span: decls_node.range().into(),
-                        });
+                        errors.push(AnnParsingError::new(
+                            ParsingError::DuplicateNameDecl { first, second },
+                            &decls_node,
+                        ));
                     }
 
                     cont_stack.push(K::ConsumeNew { decls, span });
@@ -553,13 +551,13 @@ pub(super) fn node_to_ast<'ast>(
                         let lhs_has_cont = lhs.child_by_field_id(field!("cont")).is_some();
 
                         if let_decl_is_malformed(lhs_arity, rhs_arity, lhs_has_cont) {
-                            errors.push(AnnParsingError {
-                                error: ParsingError::MalformedLetDecl {
+                            errors.push(AnnParsingError::new(
+                                ParsingError::MalformedLetDecl {
                                     lhs_arity,
                                     rhs_arity,
                                 },
-                                span: decl_node.range().into(),
-                            });
+                                &decl_node,
+                            ));
                         }
                         temp_cont_stack.push(K::EvalList(lhs.walk()));
                         temp_cont_stack.push(K::EvalList(rhs.walk()));

--- a/rholang-parser/tests/corpus/Cell3_bad.rho
+++ b/rholang-parser/tests/corpus/Cell3_bad.rho
@@ -1,0 +1,11 @@
+contract Cell( client, state ) = {
+  for( request <- client; v <- state ) {
+    match *request with
+      *@get{ #rtn } => {
+        rtn!( *v ) | state!( *v ) | Cell( *client, *state )
+      }
+      *@set{ newValue } => {
+        state!( *newValue ) | Cell( *client, *state )
+      }
+  }
+}

--- a/rholang-parser/tests/corpus/golden_snapshots/golden__Cell3.snap
+++ b/rholang-parser/tests/corpus/golden_snapshots/golden__Cell3.snap
@@ -342,9 +342,9 @@ Fail(
             ),
             errors: [
                 AnnParsingError {
-                    error: SyntaxError {
-                        sexp: "(ERROR (var) (var))",
-                    },
+                    error: UnexpectedVar(
+                        "request",
+                    ),
                     span: SourceSpan {
                         start: SourcePos {
                             line: 12,
@@ -352,7 +352,52 @@ Fail(
                         },
                         end: SourcePos {
                             line: 12,
+                            col: 17,
+                        },
+                    },
+                },
+                AnnParsingError {
+                    error: UnexpectedVar(
+                        "with",
+                    ),
+                    span: SourceSpan {
+                        start: SourcePos {
+                            line: 12,
+                            col: 18,
+                        },
+                        end: SourcePos {
+                            line: 12,
                             col: 22,
+                        },
+                    },
+                },
+                AnnParsingError {
+                    error: UnexpectedVar(
+                        "set",
+                    ),
+                    span: SourceSpan {
+                        start: SourcePos {
+                            line: 16,
+                            col: 7,
+                        },
+                        end: SourcePos {
+                            line: 16,
+                            col: 10,
+                        },
+                    },
+                },
+                AnnParsingError {
+                    error: MissingToken(
+                        "}",
+                    ),
+                    span: SourceSpan {
+                        start: SourcePos {
+                            line: 20,
+                            col: 2,
+                        },
+                        end: SourcePos {
+                            line: 20,
+                            col: 2,
                         },
                     },
                 },
@@ -388,21 +433,6 @@ Fail(
                 },
                 AnnParsingError {
                     error: SyntaxError {
-                        sexp: "(ERROR (var))",
-                    },
-                    span: SourceSpan {
-                        start: SourcePos {
-                            line: 16,
-                            col: 7,
-                        },
-                        end: SourcePos {
-                            line: 16,
-                            col: 10,
-                        },
-                    },
-                },
-                AnnParsingError {
-                    error: SyntaxError {
                         sexp: "(ERROR (par (send channel: (var) send_type: (send_single) inputs: (inputs (var))) (var)))",
                     },
                     span: SourceSpan {
@@ -413,21 +443,6 @@ Fail(
                         end: SourcePos {
                             line: 17,
                             col: 34,
-                        },
-                    },
-                },
-                AnnParsingError {
-                    error: MissingToken(
-                        "}",
-                    ),
-                    span: SourceSpan {
-                        start: SourcePos {
-                            line: 20,
-                            col: 2,
-                        },
-                        end: SourcePos {
-                            line: 20,
-                            col: 2,
                         },
                     },
                 },

--- a/rholang-parser/tests/corpus/golden_snapshots/golden__Cell3_bad.snap
+++ b/rholang-parser/tests/corpus/golden_snapshots/golden__Cell3_bad.snap
@@ -14,7 +14,7 @@ Fail(
                                     Id {
                                         name: "Cell",
                                         pos: SourcePos {
-                                            line: 10,
+                                            line: 1,
                                             col: 10,
                                         },
                                     },
@@ -22,11 +22,11 @@ Fail(
                             ),
                             span: SourceSpan {
                                 start: SourcePos {
-                                    line: 10,
+                                    line: 1,
                                     col: 10,
                                 },
                                 end: SourcePos {
-                                    line: 10,
+                                    line: 1,
                                     col: 14,
                                 },
                             },
@@ -39,7 +39,7 @@ Fail(
                                             Id {
                                                 name: "client",
                                                 pos: SourcePos {
-                                                    line: 10,
+                                                    line: 1,
                                                     col: 16,
                                                 },
                                             },
@@ -47,11 +47,11 @@ Fail(
                                     ),
                                     span: SourceSpan {
                                         start: SourcePos {
-                                            line: 10,
+                                            line: 1,
                                             col: 16,
                                         },
                                         end: SourcePos {
-                                            line: 10,
+                                            line: 1,
                                             col: 22,
                                         },
                                     },
@@ -62,7 +62,7 @@ Fail(
                                             Id {
                                                 name: "state",
                                                 pos: SourcePos {
-                                                    line: 10,
+                                                    line: 1,
                                                     col: 24,
                                                 },
                                             },
@@ -70,11 +70,11 @@ Fail(
                                     ),
                                     span: SourceSpan {
                                         start: SourcePos {
-                                            line: 10,
+                                            line: 1,
                                             col: 24,
                                         },
                                         end: SourcePos {
-                                            line: 10,
+                                            line: 1,
                                             col: 29,
                                         },
                                     },
@@ -95,7 +95,7 @@ Fail(
                                                                 Id {
                                                                     name: "request",
                                                                     pos: SourcePos {
-                                                                        line: 11,
+                                                                        line: 2,
                                                                         col: 8,
                                                                     },
                                                                 },
@@ -103,11 +103,11 @@ Fail(
                                                         ),
                                                         span: SourceSpan {
                                                             start: SourcePos {
-                                                                line: 11,
+                                                                line: 2,
                                                                 col: 8,
                                                             },
                                                             end: SourcePos {
-                                                                line: 11,
+                                                                line: 2,
                                                                 col: 15,
                                                             },
                                                         },
@@ -122,7 +122,7 @@ Fail(
                                                             Id {
                                                                 name: "client",
                                                                 pos: SourcePos {
-                                                                    line: 11,
+                                                                    line: 2,
                                                                     col: 19,
                                                                 },
                                                             },
@@ -130,11 +130,11 @@ Fail(
                                                     ),
                                                     span: SourceSpan {
                                                         start: SourcePos {
-                                                            line: 11,
+                                                            line: 2,
                                                             col: 19,
                                                         },
                                                         end: SourcePos {
-                                                            line: 11,
+                                                            line: 2,
                                                             col: 25,
                                                         },
                                                     },
@@ -152,7 +152,7 @@ Fail(
                                                                 Id {
                                                                     name: "v",
                                                                     pos: SourcePos {
-                                                                        line: 11,
+                                                                        line: 2,
                                                                         col: 27,
                                                                     },
                                                                 },
@@ -160,11 +160,11 @@ Fail(
                                                         ),
                                                         span: SourceSpan {
                                                             start: SourcePos {
-                                                                line: 11,
+                                                                line: 2,
                                                                 col: 27,
                                                             },
                                                             end: SourcePos {
-                                                                line: 11,
+                                                                line: 2,
                                                                 col: 28,
                                                             },
                                                         },
@@ -179,7 +179,7 @@ Fail(
                                                             Id {
                                                                 name: "state",
                                                                 pos: SourcePos {
-                                                                    line: 11,
+                                                                    line: 2,
                                                                     col: 32,
                                                                 },
                                                             },
@@ -187,11 +187,11 @@ Fail(
                                                     ),
                                                     span: SourceSpan {
                                                         start: SourcePos {
-                                                            line: 11,
+                                                            line: 2,
                                                             col: 32,
                                                         },
                                                         end: SourcePos {
-                                                            line: 11,
+                                                            line: 2,
                                                             col: 37,
                                                         },
                                                     },
@@ -203,25 +203,67 @@ Fail(
                                 proc: AnnProc {
                                     proc: Match {
                                         expression: AnnProc {
-                                            proc: ProcVar(
-                                                Id(
-                                                    Id {
-                                                        name: "get",
-                                                        pos: SourcePos {
-                                                            line: 13,
-                                                            col: 7,
+                                            proc: BinaryExp {
+                                                op: Mult,
+                                                left: AnnProc {
+                                                    proc: Eval {
+                                                        name: AnnName {
+                                                            name: ProcVar(
+                                                                Id(
+                                                                    Id {
+                                                                        name: "request",
+                                                                        pos: SourcePos {
+                                                                            line: 3,
+                                                                            col: 12,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            span: SourceSpan {
+                                                                start: SourcePos {
+                                                                    line: 3,
+                                                                    col: 12,
+                                                                },
+                                                                end: SourcePos {
+                                                                    line: 3,
+                                                                    col: 19,
+                                                                },
+                                                            },
                                                         },
                                                     },
-                                                ),
-                                            ),
+                                                    span: SourceSpan {
+                                                        start: SourcePos {
+                                                            line: 3,
+                                                            col: 11,
+                                                        },
+                                                        end: SourcePos {
+                                                            line: 3,
+                                                            col: 19,
+                                                        },
+                                                    },
+                                                },
+                                                right: AnnProc {
+                                                    proc: Bad,
+                                                    span: SourceSpan {
+                                                        start: SourcePos {
+                                                            line: 3,
+                                                            col: 20,
+                                                        },
+                                                        end: SourcePos {
+                                                            line: 3,
+                                                            col: 24,
+                                                        },
+                                                    },
+                                                },
+                                            },
                                             span: SourceSpan {
                                                 start: SourcePos {
-                                                    line: 13,
-                                                    col: 7,
+                                                    line: 3,
+                                                    col: 11,
                                                 },
                                                 end: SourcePos {
-                                                    line: 13,
-                                                    col: 10,
+                                                    line: 4,
+                                                    col: 12,
                                                 },
                                             },
                                         },
@@ -233,33 +275,73 @@ Fail(
                                                             Id {
                                                                 name: "rtn",
                                                                 pos: SourcePos {
-                                                                    line: 13,
-                                                                    col: 12,
+                                                                    line: 4,
+                                                                    col: 15,
                                                                 },
                                                             },
                                                         ),
                                                     ),
                                                     span: SourceSpan {
                                                         start: SourcePos {
-                                                            line: 13,
-                                                            col: 12,
+                                                            line: 4,
+                                                            col: 15,
                                                         },
                                                         end: SourcePos {
-                                                            line: 13,
-                                                            col: 15,
+                                                            line: 4,
+                                                            col: 18,
                                                         },
                                                     },
                                                 },
                                                 proc: AnnProc {
-                                                    proc: Bad,
+                                                    proc: BinaryExp {
+                                                        op: Mult,
+                                                        left: AnnProc {
+                                                            proc: Bad,
+                                                            span: SourceSpan {
+                                                                start: SourcePos {
+                                                                    line: 5,
+                                                                    col: 9,
+                                                                },
+                                                                end: SourcePos {
+                                                                    line: 5,
+                                                                    col: 41,
+                                                                },
+                                                            },
+                                                        },
+                                                        right: AnnProc {
+                                                            proc: Quote {
+                                                                proc: ProcVar(
+                                                                    Id(
+                                                                        Id {
+                                                                            name: "set",
+                                                                            pos: SourcePos {
+                                                                                line: 7,
+                                                                                col: 9,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                            span: SourceSpan {
+                                                                start: SourcePos {
+                                                                    line: 7,
+                                                                    col: 8,
+                                                                },
+                                                                end: SourcePos {
+                                                                    line: 7,
+                                                                    col: 12,
+                                                                },
+                                                            },
+                                                        },
+                                                    },
                                                     span: SourceSpan {
                                                         start: SourcePos {
-                                                            line: 14,
-                                                            col: 9,
+                                                            line: 4,
+                                                            col: 24,
                                                         },
                                                         end: SourcePos {
-                                                            line: 14,
-                                                            col: 39,
+                                                            line: 7,
+                                                            col: 12,
                                                         },
                                                     },
                                                 },
@@ -271,20 +353,20 @@ Fail(
                                                             Id {
                                                                 name: "newValue",
                                                                 pos: SourcePos {
-                                                                    line: 16,
-                                                                    col: 12,
+                                                                    line: 7,
+                                                                    col: 14,
                                                                 },
                                                             },
                                                         ),
                                                     ),
                                                     span: SourceSpan {
                                                         start: SourcePos {
-                                                            line: 16,
-                                                            col: 12,
+                                                            line: 7,
+                                                            col: 14,
                                                         },
                                                         end: SourcePos {
-                                                            line: 16,
-                                                            col: 20,
+                                                            line: 7,
+                                                            col: 22,
                                                         },
                                                     },
                                                 },
@@ -292,12 +374,12 @@ Fail(
                                                     proc: Bad,
                                                     span: SourceSpan {
                                                         start: SourcePos {
-                                                            line: 17,
+                                                            line: 8,
                                                             col: 9,
                                                         },
                                                         end: SourcePos {
-                                                            line: 17,
-                                                            col: 34,
+                                                            line: 8,
+                                                            col: 35,
                                                         },
                                                     },
                                                 },
@@ -306,11 +388,11 @@ Fail(
                                     },
                                     span: SourceSpan {
                                         start: SourcePos {
-                                            line: 12,
-                                            col: 4,
+                                            line: 3,
+                                            col: 5,
                                         },
                                         end: SourcePos {
-                                            line: 19,
+                                            line: 10,
                                             col: 4,
                                         },
                                     },
@@ -318,11 +400,11 @@ Fail(
                             },
                             span: SourceSpan {
                                 start: SourcePos {
-                                    line: 11,
+                                    line: 2,
                                     col: 3,
                                 },
                                 end: SourcePos {
-                                    line: 20,
+                                    line: 11,
                                     col: 2,
                                 },
                             },
@@ -330,11 +412,11 @@ Fail(
                     },
                     span: SourceSpan {
                         start: SourcePos {
-                            line: 10,
+                            line: 1,
                             col: 1,
                         },
                         end: SourcePos {
-                            line: 20,
+                            line: 11,
                             col: 2,
                         },
                     },
@@ -343,31 +425,16 @@ Fail(
             errors: [
                 AnnParsingError {
                     error: UnexpectedVar(
-                        "request",
-                    ),
-                    span: SourceSpan {
-                        start: SourcePos {
-                            line: 12,
-                            col: 10,
-                        },
-                        end: SourcePos {
-                            line: 12,
-                            col: 17,
-                        },
-                    },
-                },
-                AnnParsingError {
-                    error: UnexpectedVar(
                         "with",
                     ),
                     span: SourceSpan {
                         start: SourcePos {
-                            line: 12,
-                            col: 18,
+                            line: 3,
+                            col: 20,
                         },
                         end: SourcePos {
-                            line: 12,
-                            col: 22,
+                            line: 3,
+                            col: 24,
                         },
                     },
                 },
@@ -378,27 +445,12 @@ Fail(
                     },
                     span: SourceSpan {
                         start: SourcePos {
-                            line: 14,
-                            col: 39,
+                            line: 5,
+                            col: 41,
                         },
                         end: SourcePos {
-                            line: 14,
-                            col: 56,
-                        },
-                    },
-                },
-                AnnParsingError {
-                    error: UnexpectedVar(
-                        "set",
-                    ),
-                    span: SourceSpan {
-                        start: SourcePos {
-                            line: 16,
-                            col: 7,
-                        },
-                        end: SourcePos {
-                            line: 16,
-                            col: 10,
+                            line: 5,
+                            col: 60,
                         },
                     },
                 },
@@ -409,12 +461,12 @@ Fail(
                     },
                     span: SourceSpan {
                         start: SourcePos {
-                            line: 17,
-                            col: 34,
+                            line: 8,
+                            col: 35,
                         },
                         end: SourcePos {
-                            line: 17,
-                            col: 51,
+                            line: 8,
+                            col: 54,
                         },
                     },
                 },
@@ -424,12 +476,27 @@ Fail(
                     ),
                     span: SourceSpan {
                         start: SourcePos {
-                            line: 20,
+                            line: 11,
                             col: 2,
                         },
                         end: SourcePos {
-                            line: 20,
+                            line: 11,
                             col: 2,
+                        },
+                    },
+                },
+                AnnParsingError {
+                    error: Unexpected(
+                        '#',
+                    ),
+                    span: SourceSpan {
+                        start: SourcePos {
+                            line: 4,
+                            col: 14,
+                        },
+                        end: SourcePos {
+                            line: 4,
+                            col: 15,
                         },
                     },
                 },
@@ -439,12 +506,12 @@ Fail(
                     },
                     span: SourceSpan {
                         start: SourcePos {
-                            line: 13,
-                            col: 16,
+                            line: 4,
+                            col: 19,
                         },
                         end: SourcePos {
-                            line: 13,
-                            col: 17,
+                            line: 4,
+                            col: 20,
                         },
                     },
                 },

--- a/rholang-parser/tests/corpus/golden_snapshots/golden__filestore.snap
+++ b/rholang-parser/tests/corpus/golden_snapshots/golden__filestore.snap
@@ -1436,17 +1436,17 @@ Fail(
             ),
             errors: [
                 AnnParsingError {
-                    error: SyntaxError {
-                        sexp: "(ERROR (var))",
-                    },
+                    error: UnexpectedVar(
+                        "Map",
+                    ),
                     span: SourceSpan {
                         start: SourcePos {
                             line: 12,
-                            col: 11,
+                            col: 15,
                         },
                         end: SourcePos {
                             line: 12,
-                            col: 20,
+                            col: 18,
                         },
                     },
                 },


### PR DESCRIPTION
This PR adds more precise error detection for the parser. It uses more complex tree-sitter queries to add better error handling. The PR also serves as a sketch for adding more error detection procedures later on.