### PR TITLE
serve only wasm file in js bindings

### DIFF
--- a/rholang-tree-sitter/bindings/js/package.json
+++ b/rholang-tree-sitter/bindings/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f1r3fly-io/tree-sitter-rholang-js",
+  "name": "@f1r3fly-io/tree-sitter-rholang-js-with-comments",
   "version": "1.1.5",
   "description": "Parser for Rholang (Mercury)",
   "repository": {
@@ -40,8 +40,5 @@
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2",
     "vite": "^7.1.4"
-  },
-  "dependencies": {
-    "web-tree-sitter": "^0.25.8"
   }
 }

--- a/rholang-tree-sitter/bindings/js/src/index.ts
+++ b/rholang-tree-sitter/bindings/js/src/index.ts
@@ -1,17 +1,2 @@
-import { Language, Parser } from "web-tree-sitter";
-
-let lang: Language | null = null;
-
-export default async function loadParser(): Promise<Parser> {
-  if (!lang) {
-    await Parser.init();
-    const wasmUrl = new URL("../tree-sitter-rholang.wasm", import.meta.url);
-    lang = await Language.load(wasmUrl.toString());
-  }
-
-  const parser = new Parser();
-  parser.setLanguage(lang);
-  return parser;
-}
-
-export { loadParser };
+import wasm from "../tree-sitter-rholang.wasm?url&inline";
+export { wasm };

--- a/rholang-tree-sitter/bindings/js/src/vite-env.d.ts
+++ b/rholang-tree-sitter/bindings/js/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
- remove web-tree-sitter dependency
- include only wasm object

This should be back ported to original rholang-rs