### PR TITLE
remove web tree sitter in js bindings

### DIFF
--- a/.github/workflows/js-bindings.yaml
+++ b/.github/workflows/js-bindings.yaml
@@ -8,8 +8,6 @@ on:
     branches: [main]
     paths:
       - "rholang-tree-sitter/**"
-      - "!rholang-tree-sitter/bindings/*/**"
-      - "rholang-tree-sitter/bindings/js/**"
 
 jobs:
   publish:

--- a/rholang-tree-sitter/bindings/js/package.json
+++ b/rholang-tree-sitter/bindings/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f1r3fly-io/tree-sitter-rholang-js",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "description": "Parser for Rholang (Mercury)",
   "repository": {
     "type": "git",
@@ -40,8 +40,5 @@
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2",
     "vite": "^7.1.4"
-  },
-  "dependencies": {
-    "web-tree-sitter": "^0.25.8"
   }
 }

--- a/rholang-tree-sitter/bindings/js/src/index.ts
+++ b/rholang-tree-sitter/bindings/js/src/index.ts
@@ -1,17 +1,2 @@
-import { Language, Parser } from "web-tree-sitter";
-
-let lang: Language | null = null;
-
-export default async function loadParser(): Promise<Parser> {
-  if (!lang) {
-    await Parser.init();
-    const wasmUrl = new URL("../tree-sitter-rholang.wasm", import.meta.url);
-    lang = await Language.load(wasmUrl.toString());
-  }
-
-  const parser = new Parser();
-  parser.setLanguage(lang);
-  return parser;
-}
-
-export { loadParser };
+import wasm from "../tree-sitter-rholang.wasm?url&inline";
+export { wasm };

--- a/rholang-tree-sitter/bindings/js/src/vite-env.d.ts
+++ b/rholang-tree-sitter/bindings/js/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
there is no need to inlude web tree sitter in js bindings. clients can download it