### PR TITLE
feat: add extended numeric types (Float, BigInt, BigRat, FixedPoint)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,12 @@ clap = { version = "4.5.40", features = ["derive"] }
 
 async-std = { version = "1.13.1", features = ["attributes"] }
 
+# Used by: rholang-rspace, rholang-vm, rholang-compiler, rholang-shell
+num-bigint = "0.4"
+num-rational = "0.4"
+num-traits = "0.2"
+num-integer = "0.1"
+
 # Used by: rholang-shell, rholang-parser
 rstest = "0.26.1"
 

--- a/rholang-bytecode/src/core/opcodes.rs
+++ b/rholang-bytecode/src/core/opcodes.rs
@@ -24,6 +24,10 @@ pub enum Opcode {
     PUSH_PROC = 0x13,
     PUSH_NAME = 0x14,
     PUSH_NIL = 0x15,
+    /// Push typed constant from constant pool, 1 operand (pool index).
+    /// Used for numeric values that don't fit in instruction immediates:
+    /// Float, BigInt, BigRat, FixedPoint, and integers outside i16 range.
+    PUSH_CONST = 0x19,
     POP = 0x16,
     DUP = 0x17,
     SWAP = 0x18,
@@ -123,6 +127,7 @@ impl Opcode {
         table[0x13] = Some(Opcode::PUSH_PROC);
         table[0x14] = Some(Opcode::PUSH_NAME);
         table[0x15] = Some(Opcode::PUSH_NIL);
+        table[0x19] = Some(Opcode::PUSH_CONST);
         table[0x16] = Some(Opcode::POP);
         table[0x17] = Some(Opcode::DUP);
         table[0x18] = Some(Opcode::SWAP);
@@ -255,6 +260,7 @@ impl Opcode {
         counts[0x12] = 1; // PUSH_BOOL
         counts[0x13] = 1; // PUSH_PROC
         counts[0x14] = 1; // PUSH_NAME
+        counts[0x19] = 1; // PUSH_CONST
         counts[0x20] = 1; // LOAD_VAR
         counts[0x21] = 1; // LOAD_LOCAL
         counts[0x22] = 1; // STORE_LOCAL

--- a/rholang-compiler/Cargo.toml
+++ b/rholang-compiler/Cargo.toml
@@ -13,6 +13,10 @@ doctest = false
 # Workspace dependencies
 anyhow = { workspace = true }
 validated = { workspace = true }
+num-bigint = { workspace = true }
+num-rational = { workspace = true }
+num-traits = { workspace = true }
+num-integer = { workspace = true }
 
 # Local crates
 rholang-parser = { path = "../rholang-parser" }
@@ -20,6 +24,7 @@ rholang-bytecode = { path = "../rholang-bytecode" }
 librho = { path = "../rholang-lib", package = "rholang-lib" }
 rholang-vm = { path = "../rholang-vm" }
 rholang-process = { path = "../rholang-process" }
+rholang-rspace = { path = "../rholang-rspace", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/rholang-compiler/src/codegen.rs
+++ b/rholang-compiler/src/codegen.rs
@@ -5,6 +5,8 @@
 
 use anyhow::{anyhow, bail, Result};
 use librho::sem::{BinderId, SemanticDb, SymbolOccurrence, PID};
+use num_bigint::BigInt;
+use num_rational::BigRational;
 use rholang_bytecode::core::{instructions::Instruction, opcodes::Opcode};
 use rholang_parser::ast::{
     AnnProc, BinaryExpOp, Bind, Collection, Name, Proc, Receipts, Source, Var,
@@ -21,6 +23,10 @@ pub struct CodegenContext<'a> {
 
     /// String pool for string literals (index -> string)
     strings: Vec<String>,
+
+    /// Typed constant pool for numeric values (Float, BigInt, BigRat, FixedPoint,
+    /// and integers outside i16 range). Indexed by PUSH_CONST operand.
+    constants: Vec<Value>,
 
     /// Map from variable binder IDs to local slot indices
     locals: HashMap<BinderId, u16>,
@@ -52,6 +58,7 @@ impl<'a> CodegenContext<'a> {
             db,
             instructions: Vec::new(),
             strings: Vec::new(),
+            constants: Vec::new(),
             locals: HashMap::new(),
             next_local: 0,
             labels: HashMap::new(),
@@ -86,6 +93,30 @@ impl<'a> CodegenContext<'a> {
 
             Proc::LongLiteral(n) => {
                 self.emit_int(*n)?;
+            }
+
+            Proc::SignedIntLiteral { value, bits } => {
+                self.compile_signed_int(value, *bits)?;
+            }
+
+            Proc::UnsignedIntLiteral { value, bits } => {
+                self.compile_unsigned_int(value, *bits)?;
+            }
+
+            Proc::BigIntLiteral(s) => {
+                self.compile_bigint(s)?;
+            }
+
+            Proc::BigRatLiteral(s) => {
+                self.compile_bigrat(s)?;
+            }
+
+            Proc::FloatLiteral { value, bits } => {
+                self.compile_float(value, *bits)?;
+            }
+
+            Proc::FixedPointLiteral { value, scale } => {
+                self.compile_fixed_point(value, *scale)?;
             }
 
             Proc::StringLiteral(s) => {
@@ -182,30 +213,159 @@ impl<'a> CodegenContext<'a> {
         self.instructions.push(inst);
     }
 
-    /// Emit an integer literal instruction
+    /// Emit an integer literal instruction.
     ///
-    /// In MVP, we only support integers that fit in i16 range for simplicity
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the integer is outside the i16 range.
+    /// Values in i16 range use PUSH_INT (inline immediate).
+    /// Values outside i16 range use PUSH_CONST (constant pool).
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn emit_int(&mut self, n: i64) -> Result<()> {
-        if n < i16::MIN as i64 || n > i16::MAX as i64 {
+        if n >= i16::MIN as i64 && n <= i16::MAX as i64 {
+            let bits = (n as i16) as u16;
+            self.emit(Instruction::unary(Opcode::PUSH_INT, bits));
+        } else {
+            let idx = self.add_constant(Value::Int(n));
+            self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
+        }
+        Ok(())
+    }
+
+    /// Add a typed constant to the constant pool and return its index.
+    #[allow(clippy::cast_possible_truncation)]
+    fn add_constant(&mut self, val: Value) -> u16 {
+        // Deduplicate: reuse existing index if an equal constant already exists
+        if let Some(idx) = self.constants.iter().position(|c| c == &val) {
+            return idx as u16;
+        }
+        let idx = self.constants.len();
+        assert!(
+            idx <= u16::MAX as usize,
+            "Constant pool overflow (max {} constants)",
+            u16::MAX
+        );
+        self.constants.push(val);
+        idx as u16
+    }
+
+    /// Compile a signed integer literal (e.g., `-52i64`, `127i8`).
+    fn compile_signed_int(&mut self, value: &str, bits: u32) -> Result<()> {
+        let n: i128 = value
+            .parse()
+            .map_err(|e| anyhow!("Invalid signed integer literal '{}': {}", value, e))?;
+
+        let max = 1i128 << (bits - 1);
+        let min = -max;
+        if n < min || n >= max {
             bail!(
-                "Integer literal {n} out of range for MVP (must fit in i16: {} to {})",
-                i16::MIN,
-                i16::MAX
+                "Signed integer literal {} out of range for i{} ({} to {})",
+                value,
+                bits,
+                min,
+                max - 1
             );
         }
 
-        // Cast is safe because we checked the range above
-        let value = n as i16;
+        if bits <= 64 {
+            self.emit_int(n as i64)
+        } else {
+            let big = BigInt::from(n);
+            let idx = self.add_constant(Value::BigInt(big));
+            self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
+            Ok(())
+        }
+    }
 
-        // Reinterpret bits to store as u16
-        let bits = value as u16;
+    /// Compile an unsigned integer literal (e.g., `65535u16`, `255u8`).
+    fn compile_unsigned_int(&mut self, value: &str, bits: u32) -> Result<()> {
+        let n: u128 = value
+            .parse()
+            .map_err(|e| anyhow!("Invalid unsigned integer literal '{}': {}", value, e))?;
 
-        self.emit(Instruction::unary(Opcode::PUSH_INT, bits));
+        let max = if bits >= 128 {
+            u128::MAX
+        } else {
+            (1u128 << bits) - 1
+        };
+        if n > max {
+            bail!(
+                "Unsigned integer literal {} out of range for u{} (0 to {})",
+                value,
+                bits,
+                max
+            );
+        }
+
+        if n <= i64::MAX as u128 {
+            self.emit_int(n as i64)
+        } else {
+            let big = BigInt::from(n);
+            Value::check_bigint_size(&big)
+                .map_err(|e| anyhow!("Unsigned integer literal {}{}: {}", value, bits, e))?;
+            let idx = self.add_constant(Value::BigInt(big));
+            self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
+            Ok(())
+        }
+    }
+
+    /// Compile a BigInt literal (e.g., `10n`, `-1n`).
+    fn compile_bigint(&mut self, s: &str) -> Result<()> {
+        let n: BigInt = s
+            .parse()
+            .map_err(|e| anyhow!("Invalid bigint literal '{}n': {}", s, e))?;
+        Value::check_bigint_size(&n)
+            .map_err(|e| anyhow!("BigInt literal {}n: {}", s, e))?;
+        let idx = self.add_constant(Value::BigInt(n));
+        self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
+        Ok(())
+    }
+
+    /// Compile a BigRat literal (e.g., `3r`, `-1r`).
+    fn compile_bigrat(&mut self, s: &str) -> Result<()> {
+        let n: BigInt = s
+            .parse()
+            .map_err(|e| anyhow!("Invalid bigrat literal '{}r': {}", s, e))?;
+        let r = BigRational::from(n);
+        let idx = self.add_constant(Value::BigRat(r));
+        self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
+        Ok(())
+    }
+
+    /// Compile a float literal (e.g., `-1.234e5f32`, `3.14f64`).
+    fn compile_float(&mut self, value: &str, bits: u16) -> Result<()> {
+        match bits {
+            32 | 64 => {}
+            other => bail!(
+                "Float width f{} not supported at runtime (only f32 and f64)",
+                other
+            ),
+        }
+
+        let f: f64 = value
+            .parse()
+            .map_err(|e| anyhow!("Invalid float literal '{}f{}': {}", value, bits, e))?;
+
+        if bits == 32 {
+            let f32_val = f as f32;
+            if f32_val.is_infinite() && !f.is_infinite() {
+                bail!(
+                    "Float literal '{}' overflows f32 (would become Inf)",
+                    value
+                );
+            }
+        }
+
+        let idx = self.add_constant(Value::Float(f));
+        self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
+        Ok(())
+    }
+
+    /// Compile a fixed-point literal (e.g., `3.3p1`, `0.25p2`, `100p0`).
+    fn compile_fixed_point(&mut self, value: &str, scale: u32) -> Result<()> {
+        let unscaled = parse_fixed_point_unscaled(value, scale)?;
+        Value::check_bigint_size(&unscaled).map_err(|e| {
+            anyhow!("FixedPoint literal '{}p{}': {}", value, scale, e)
+        })?;
+        let idx = self.add_constant(Value::FixedPoint { unscaled, scale });
+        self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
         Ok(())
     }
 
@@ -246,6 +406,7 @@ impl<'a> CodegenContext<'a> {
             BinaryExpOp::Sub => Opcode::SUB,
             BinaryExpOp::Mult => Opcode::MUL,
             BinaryExpOp::Div => Opcode::DIV,
+            BinaryExpOp::Mod => Opcode::MOD,
 
             // Comparison operators
             BinaryExpOp::Eq => Opcode::CMP_EQ,
@@ -721,7 +882,48 @@ impl<'a> CodegenContext<'a> {
         // Convert string pool to Value::Str
         process.names = self.strings.into_iter().map(Value::Str).collect();
 
+        // Set the constant pool
+        process.constants = self.constants;
+
         Ok(process)
+    }
+}
+
+/// Parse a fixed-point literal value string into an unscaled BigInt.
+///
+/// For example, `"3.3"` with scale=1 → unscaled=33.
+/// `"100"` with scale=0 → unscaled=100.
+/// `"0.25"` with scale=2 → unscaled=25.
+fn parse_fixed_point_unscaled(value: &str, scale: u32) -> Result<BigInt> {
+    let scale = scale as usize;
+
+    if let Some(dot_pos) = value.find('.') {
+        let integer_part = &value[..dot_pos];
+        let frac_part = &value[dot_pos + 1..];
+
+        if frac_part.len() > scale {
+            bail!(
+                "Fixed-point literal '{}p{}' has {} fractional digits but scale is {}",
+                value,
+                scale,
+                frac_part.len(),
+                scale
+            );
+        }
+
+        // Pad fractional part to match scale
+        let padded_frac = format!("{:0<width$}", frac_part, width = scale);
+        let combined = format!("{}{}", integer_part, padded_frac);
+        combined
+            .parse::<BigInt>()
+            .map_err(|e| anyhow!("Invalid fixed-point literal '{}p{}': {}", value, scale, e))
+    } else {
+        // No decimal point — multiply by 10^scale
+        let base: BigInt = value
+            .parse()
+            .map_err(|e| anyhow!("Invalid fixed-point literal '{}p{}': {}", value, scale, e))?;
+        let multiplier = num_traits::pow::pow(BigInt::from(10), scale);
+        Ok(base * multiplier)
     }
 }
 
@@ -797,14 +999,21 @@ mod tests {
     }
 
     #[test]
-    fn test_compile_int_out_of_range() {
+    fn test_compile_int_large_uses_constant_pool() {
         let db = SemanticDb::new();
         let proc = Proc::LongLiteral(100_000);
         let mut ctx = CodegenContext::new(&db, 0);
 
         let result = ctx.compile_proc(&ann_proc(&proc));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("out of range"));
+        assert!(result.is_ok(), "large int should compile via constant pool");
+        // Verify a PUSH_CONST instruction was emitted
+        assert!(
+            ctx.instructions
+                .iter()
+                .any(|i| i.opcode().map(|o| o == Opcode::PUSH_CONST).unwrap_or(false)),
+            "should emit PUSH_CONST for out-of-i16-range integer"
+        );
+        assert_eq!(ctx.constants.len(), 1);
     }
 
     #[test]

--- a/rholang-compiler/src/codegen.rs
+++ b/rholang-compiler/src/codegen.rs
@@ -298,8 +298,6 @@ impl<'a> CodegenContext<'a> {
             self.emit_int(n as i64)
         } else {
             let big = BigInt::from(n);
-            Value::check_bigint_size(&big)
-                .map_err(|e| anyhow!("Unsigned integer literal {}{}: {}", value, bits, e))?;
             let idx = self.add_constant(Value::BigInt(big));
             self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
             Ok(())
@@ -311,8 +309,6 @@ impl<'a> CodegenContext<'a> {
         let n: BigInt = s
             .parse()
             .map_err(|e| anyhow!("Invalid bigint literal '{}n': {}", s, e))?;
-        Value::check_bigint_size(&n)
-            .map_err(|e| anyhow!("BigInt literal {}n: {}", s, e))?;
         let idx = self.add_constant(Value::BigInt(n));
         self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
         Ok(())
@@ -361,9 +357,6 @@ impl<'a> CodegenContext<'a> {
     /// Compile a fixed-point literal (e.g., `3.3p1`, `0.25p2`, `100p0`).
     fn compile_fixed_point(&mut self, value: &str, scale: u32) -> Result<()> {
         let unscaled = parse_fixed_point_unscaled(value, scale)?;
-        Value::check_bigint_size(&unscaled).map_err(|e| {
-            anyhow!("FixedPoint literal '{}p{}': {}", value, scale, e)
-        })?;
         let idx = self.add_constant(Value::FixedPoint { unscaled, scale });
         self.emit(Instruction::unary(Opcode::PUSH_CONST, idx));
         Ok(())

--- a/rholang-compiler/src/disassembler.rs
+++ b/rholang-compiler/src/disassembler.rs
@@ -269,6 +269,7 @@ impl Disassembler {
             Opcode::PUSH_PROC => format!("Push process at index {}", inst.op16()),
             Opcode::PUSH_NAME => format!("Push name at index {}", inst.op16()),
             Opcode::PUSH_NIL => "Push nil".to_string(),
+            Opcode::PUSH_CONST => format!("Push constant at index {}", inst.op16()),
             Opcode::POP => "Pop top of stack".to_string(),
             Opcode::DUP => "Duplicate top of stack".to_string(),
             Opcode::SWAP => "Swap top two stack values".to_string(),

--- a/rholang-compiler/tests/generate_examples.rs
+++ b/rholang-compiler/tests/generate_examples.rs
@@ -64,30 +64,11 @@ fn compile_and_disassemble(source: &str) -> Result<(Process, String)> {
 
 fn format_value(v: &Value) -> String {
     match v {
-        Value::Nil => "Nil".to_string(),
-        Value::Int(i) => i.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Str(s) => format!("\"{}\"", s),
-        Value::List(items) => {
-            let inner: Vec<String> = items.iter().map(format_value).collect();
-            format!("[{}]", inner.join(", "))
-        }
-        Value::Tuple(items) => {
-            let inner: Vec<String> = items.iter().map(format_value).collect();
-            format!("({})", inner.join(", "))
-        }
-        Value::Name(n) => format!("@\"{}\"", n),
-        Value::Map(m) => {
-            let inner: Vec<String> = m
-                .iter()
-                .map(|(k, v)| format!("{}: {}", format_value(k), format_value(v)))
-                .collect();
-            format!("{{{}}}", inner.join(", "))
-        }
         Value::Par(ps) => {
             let inner: Vec<String> = ps.iter().map(|p| format!("<{}>", p.source_ref())).collect();
             inner.join(" | ")
         }
+        other => other.to_string(),
     }
 }
 

--- a/rholang-compiler/tests/literals.rs
+++ b/rholang-compiler/tests/literals.rs
@@ -73,17 +73,17 @@ fn test_int_large_negative() {
 }
 
 #[test]
-#[should_panic(expected = "out of range")]
-fn test_int_out_of_range_positive() {
-    let source = "100000"; // Beyond i16::MAX
-    compile_and_run(source).unwrap();
+fn test_int_out_of_range_positive_uses_constant_pool() {
+    let source = "100000"; // Beyond i16::MAX, uses PUSH_CONST
+    let result = compile_and_run(source).unwrap();
+    assert_eq!(result, Value::Int(100_000));
 }
 
 #[test]
-#[should_panic(expected = "out of range")]
-fn test_int_out_of_range_negative() {
-    let source = "-100000"; // Beyond i16::MIN
-    compile_and_run(source).unwrap();
+fn test_int_out_of_range_negative_uses_constant_pool() {
+    let source = "-100000"; // Beyond i16::MIN, uses PUSH_CONST
+    let result = compile_and_run(source).unwrap();
+    assert_eq!(result, Value::Int(-100_000));
 }
 
 // === String Tests ===

--- a/rholang-compiler/tests/numeric_types.rs
+++ b/rholang-compiler/tests/numeric_types.rs
@@ -47,7 +47,7 @@ fn test_bigrat_literals_and_arithmetic() {
 
 #[test]
 fn test_float_literals_and_arithmetic() {
-    assert_eq!(compile_and_run("3.14f64").unwrap(), Value::Float(3.14));
+    assert_eq!(compile_and_run("3.15f64").unwrap(), Value::Float(3.15));
     assert_eq!(compile_and_run("2.5f32").unwrap(), Value::Float(2.5_f32 as f64)); // f32 stored as f64
     assert_eq!(compile_and_run("-1.5f64").unwrap(), Value::Float(-1.5));
     assert_eq!(compile_and_run("1.5e2f64").unwrap(), Value::Float(150.0)); // scientific notation
@@ -66,8 +66,8 @@ fn test_fixedpoint_literals_and_arithmetic() {
 
     assert_eq!(compile_and_run("1.50p2 + 2.25p2").unwrap(), fixed(375, 2));
     assert_eq!(compile_and_run("5.00p2 - 3.25p2").unwrap(), fixed(175, 2));
-    // Scale doubles on mul: 1.5p1 * 2.0p1 = 3.00p2
-    assert_eq!(compile_and_run("1.5p1 * 2.0p1").unwrap(), fixed(300, 2));
+    // Scale-preserving mul: 1.5p1 * 2.0p1 = 3.0p1 (unscaled: (15*20)/10 = 30)
+    assert_eq!(compile_and_run("1.5p1 * 2.0p1").unwrap(), fixed(30, 1));
     // Spec: 10p1 / 3p1 == 3.3p1
     assert_eq!(compile_and_run("10.0p1 / 3.0p1").unwrap(), fixed(33, 1));
 }

--- a/rholang-compiler/tests/numeric_types.rs
+++ b/rholang-compiler/tests/numeric_types.rs
@@ -1,0 +1,107 @@
+mod common;
+
+use common::*;
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use rholang_vm::api::Value;
+
+fn bigrat(n: i64, d: i64) -> Value {
+    Value::BigRat(BigRational::new(BigInt::from(n), BigInt::from(d)))
+}
+
+fn fixed(unscaled: i64, scale: u32) -> Value {
+    Value::FixedPoint {
+        unscaled: BigInt::from(unscaled),
+        scale,
+    }
+}
+
+// ==========================================================================
+// Literal parsing + compilation for each numeric type
+// ==========================================================================
+
+#[test]
+fn test_bigint_literals_and_arithmetic() {
+    assert_eq!(compile_and_run("42n").unwrap(), Value::BigInt(BigInt::from(42)));
+    assert_eq!(compile_and_run("-7n").unwrap(), Value::BigInt(BigInt::from(-7)));
+    assert_eq!(compile_and_run("0n").unwrap(), Value::BigInt(BigInt::from(0)));
+
+    // Spec: 10n / 3n == 3n, 10n % 3n == 1n
+    assert_eq!(compile_and_run("10n + 20n").unwrap(), Value::BigInt(BigInt::from(30)));
+    assert_eq!(compile_and_run("50n - 30n").unwrap(), Value::BigInt(BigInt::from(20)));
+    assert_eq!(compile_and_run("6n * 7n").unwrap(), Value::BigInt(BigInt::from(42)));
+    assert_eq!(compile_and_run("100n / 7n").unwrap(), Value::BigInt(BigInt::from(14)));
+}
+
+#[test]
+fn test_bigrat_literals_and_arithmetic() {
+    assert_eq!(compile_and_run("3r").unwrap(), bigrat(3, 1));
+    assert_eq!(compile_and_run("-5r").unwrap(), bigrat(-5, 1));
+
+    // Spec: 10r / 3r == 10/3 (exact rational division)
+    assert_eq!(compile_and_run("3r + 4r").unwrap(), bigrat(7, 1));
+    assert_eq!(compile_and_run("10r - 3r").unwrap(), bigrat(7, 1));
+    assert_eq!(compile_and_run("3r * 4r").unwrap(), bigrat(12, 1));
+    assert_eq!(compile_and_run("10r / 3r").unwrap(), bigrat(10, 3));
+}
+
+#[test]
+fn test_float_literals_and_arithmetic() {
+    assert_eq!(compile_and_run("3.14f64").unwrap(), Value::Float(3.14));
+    assert_eq!(compile_and_run("2.5f32").unwrap(), Value::Float(2.5_f32 as f64)); // f32 stored as f64
+    assert_eq!(compile_and_run("-1.5f64").unwrap(), Value::Float(-1.5));
+    assert_eq!(compile_and_run("1.5e2f64").unwrap(), Value::Float(150.0)); // scientific notation
+
+    assert_eq!(compile_and_run("1.5f64 + 2.25f64").unwrap(), Value::Float(3.75));
+    assert_eq!(compile_and_run("5.0f64 - 3.0f64").unwrap(), Value::Float(2.0));
+    assert_eq!(compile_and_run("2.0f64 * 3.0f64").unwrap(), Value::Float(6.0));
+    assert_eq!(compile_and_run("10.0f64 / 4.0f64").unwrap(), Value::Float(2.5));
+}
+
+#[test]
+fn test_fixedpoint_literals_and_arithmetic() {
+    // 1.50p2 => unscaled=150, scale=2
+    assert_eq!(compile_and_run("1.50p2").unwrap(), fixed(150, 2));
+    assert_eq!(compile_and_run("-3.0p1").unwrap(), fixed(-30, 1));
+
+    assert_eq!(compile_and_run("1.50p2 + 2.25p2").unwrap(), fixed(375, 2));
+    assert_eq!(compile_and_run("5.00p2 - 3.25p2").unwrap(), fixed(175, 2));
+    // Scale doubles on mul: 1.5p1 * 2.0p1 = 3.00p2
+    assert_eq!(compile_and_run("1.5p1 * 2.0p1").unwrap(), fixed(300, 2));
+    // Spec: 10p1 / 3p1 == 3.3p1
+    assert_eq!(compile_and_run("10.0p1 / 3.0p1").unwrap(), fixed(33, 1));
+}
+
+// ==========================================================================
+// Signed/Unsigned integer literals (width-qualified)
+// ==========================================================================
+
+#[test]
+fn test_signed_int_literals() {
+    // i64 is same as unqualified: -52i64 == -52
+    assert_eq!(compile_and_run("42i64").unwrap(), Value::Int(42));
+    assert_eq!(compile_and_run("-52i64").unwrap(), Value::Int(-52));
+    // Small width that fits in i64
+    assert_eq!(compile_and_run("127i8").unwrap(), Value::Int(127));
+}
+
+#[test]
+fn test_unsigned_int_literals() {
+    assert_eq!(compile_and_run("255u8").unwrap(), Value::Int(255));
+    assert_eq!(compile_and_run("0u64").unwrap(), Value::Int(0));
+    assert_eq!(compile_and_run("65535u16").unwrap(), Value::Int(65535));
+}
+
+// ==========================================================================
+// Comparisons across extended types
+// ==========================================================================
+
+#[test]
+fn test_extended_type_comparisons() {
+    assert_eq!(compile_and_run("42n == 42n").unwrap(), Value::Bool(true));
+    assert_eq!(compile_and_run("42n != 43n").unwrap(), Value::Bool(true));
+    assert_eq!(compile_and_run("1n < 2n").unwrap(), Value::Bool(true));
+    assert_eq!(compile_and_run("3.14f64 == 3.14f64").unwrap(), Value::Bool(true));
+    assert_eq!(compile_and_run("1.0f64 < 2.0f64").unwrap(), Value::Bool(true));
+    assert_eq!(compile_and_run("5r == 5r").unwrap(), Value::Bool(true));
+}

--- a/rholang-interpreter/Cargo.toml
+++ b/rholang-interpreter/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies]
 anyhow = { workspace = true }
 validated = { workspace = true }
+num-bigint = { workspace = true }
 rholang-compiler = { path = "../rholang-compiler" }
 rholang-vm = { path = "../rholang-vm" }
 async-trait = { workspace = true }

--- a/rholang-interpreter/src/lib.rs
+++ b/rholang-interpreter/src/lib.rs
@@ -79,25 +79,6 @@ impl RholangCompilerInterpreterProvider {
 
     fn render_value(v: &VmValue) -> String {
         match v {
-            VmValue::Int(n) => n.to_string(),
-            VmValue::Bool(b) => b.to_string(),
-            VmValue::Str(s) => format!("\"{}\"", s),
-            VmValue::Name(n) => format!("@{}", n),
-            VmValue::List(items) => {
-                let inner: Vec<String> = items.iter().map(Self::render_value).collect();
-                format!("[{}]", inner.join(", "))
-            }
-            VmValue::Tuple(items) => {
-                let inner: Vec<String> = items.iter().map(Self::render_value).collect();
-                format!("({})", inner.join(", "))
-            }
-            VmValue::Map(entries) => {
-                let inner: Vec<String> = entries
-                    .iter()
-                    .map(|(k, v)| format!("{}: {}", Self::render_value(k), Self::render_value(v)))
-                    .collect();
-                format!("{{{}}}", inner.join(", "))
-            }
             VmValue::Par(procs) => {
                 let inner: Vec<String> = procs
                     .iter()
@@ -105,7 +86,7 @@ impl RholangCompilerInterpreterProvider {
                     .collect();
                 inner.join(" | ")
             }
-            VmValue::Nil => "Nil".to_string(),
+            other => other.to_string(),
         }
     }
 }

--- a/rholang-process/src/process.rs
+++ b/rholang-process/src/process.rs
@@ -12,6 +12,9 @@ pub struct Process {
     pub source_ref: String,
     pub locals: Vec<Value>,
     pub names: Vec<Value>,
+    /// Typed constant pool for numeric values (Float, BigInt, BigRat, FixedPoint,
+    /// and integers outside i16 range). Indexed by PUSH_CONST operand.
+    pub constants: Vec<Value>,
     pub vm: VM,
     pub state: ProcessState,
     /// Named parameter bindings that must be solved before execution
@@ -33,6 +36,7 @@ impl Process {
             source_ref: source_ref.into(),
             locals: Vec::new(),
             names: Vec::new(),
+            constants: Vec::new(),
             vm: VM::new(),
             state: ProcessState::Ready,
             parameters: Vec::new(),
@@ -46,6 +50,7 @@ impl Process {
             source_ref: source_ref.into(),
             locals: Vec::new(),
             names: Vec::new(),
+            constants: Vec::new(),
             vm,
             state: ProcessState::Ready,
             parameters: Vec::new(),
@@ -158,7 +163,7 @@ impl Process {
             }
 
             let inst = code[pc];
-            match self.vm.execute(&mut self.locals, &self.names, inst) {
+            match self.vm.execute(&mut self.locals, &self.names, &self.constants, inst) {
                 Ok(StepResult::Next) => {
                     pc += 1;
                 }
@@ -249,6 +254,14 @@ impl fmt::Display for Process {
             writeln!(f, "\n[Parameters] ({} entries)", self.parameters.len())?;
             for (idx, param) in self.parameters.iter().enumerate() {
                 writeln!(f, "  [{}]: {}", idx, param.name())?;
+            }
+        }
+
+        // Constants pool section
+        if !self.constants.is_empty() {
+            writeln!(f, "\n[Constants Pool] ({} entries)", self.constants.len())?;
+            for (idx, val) in self.constants.iter().enumerate() {
+                writeln!(f, "  [{}]: {:?}", idx, val)?;
             }
         }
 

--- a/rholang-rspace/Cargo.toml
+++ b/rholang-rspace/Cargo.toml
@@ -18,6 +18,10 @@ inmemory-impl = []
 
 [dependencies]
 anyhow = { workspace = true }
+num-bigint = { workspace = true }
+num-rational = { workspace = true }
+num-traits = { workspace = true }
+num-integer = { workspace = true }
 
 # Optional: PathMap for hierarchical key storage (default)
 pathmap = { version = "0.2.2", optional = true }

--- a/rholang-rspace/src/lib.rs
+++ b/rholang-rspace/src/lib.rs
@@ -230,7 +230,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 pub use entry::Entry;
 pub use error::ExecError;
 pub use rspace::RSpace;
-pub use value::{ProcessHolder, ProcessState, Value, BIGINT_MAX_BYTES};
+pub use value::{ProcessHolder, ProcessState, Value};
 
 // ============================================================================
 // Public API - Implementations

--- a/rholang-rspace/src/lib.rs
+++ b/rholang-rspace/src/lib.rs
@@ -230,7 +230,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 pub use entry::Entry;
 pub use error::ExecError;
 pub use rspace::RSpace;
-pub use value::{ProcessHolder, ProcessState, Value};
+pub use value::{ProcessHolder, ProcessState, Value, BIGINT_MAX_BYTES};
 
 // ============================================================================
 // Public API - Implementations

--- a/rholang-rspace/src/value.rs
+++ b/rholang-rspace/src/value.rs
@@ -69,8 +69,6 @@ impl PartialEq for Box<dyn ProcessHolder> {
     }
 }
 
-/// Maximum byte length for BigInt values (1024 bits = 128 bytes).
-pub const BIGINT_MAX_BYTES: usize = 128;
 
 /// Runtime value in RSpace.
 ///
@@ -261,19 +259,6 @@ impl Value {
             Value::Map(_) => "Map",
             Value::Par(_) => "Par",
             Value::Nil => "Nil",
-        }
-    }
-
-    /// Check if a BigInt value exceeds the maximum allowed size.
-    pub fn check_bigint_size(n: &BigInt) -> Result<(), String> {
-        let byte_len = n.to_signed_bytes_be().len();
-        if byte_len > BIGINT_MAX_BYTES {
-            Err(format!(
-                "BigInt exceeds 1024-bit maximum ({} bytes, max {})",
-                byte_len, BIGINT_MAX_BYTES
-            ))
-        } else {
-            Ok(())
         }
     }
 
@@ -528,25 +513,6 @@ mod tests {
             Value::Int(1).partial_cmp(&Value::BigInt(BigInt::from(1))),
             None
         );
-    }
-
-    #[test]
-    fn test_bigint_size_check() {
-        // Small value: ok
-        assert!(Value::check_bigint_size(&BigInt::from(42)).is_ok());
-
-        // Value that fits in 128 bytes: ok
-        // Max positive value in 128 bytes signed = 2^1023 - 1
-        let max_val = (BigInt::from(1) << 1023) - 1;
-        assert!(Value::check_bigint_size(&max_val).is_ok());
-
-        // 1 << 1023 requires 129 bytes in signed two's complement (leading 0x00 byte)
-        let over_val = BigInt::from(1) << 1023;
-        assert!(Value::check_bigint_size(&over_val).is_err());
-
-        // ETH uint256 max (2^256 - 1): fits easily within 128 bytes
-        let eth_max = (BigInt::from(1) << 256) - 1;
-        assert!(Value::check_bigint_size(&eth_max).is_ok());
     }
 
     #[test]

--- a/rholang-rspace/src/value.rs
+++ b/rholang-rspace/src/value.rs
@@ -1,7 +1,11 @@
 //! Core value types for RSpace storage.
 
 use crate::ExecError;
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::Zero;
 use std::any::Any;
+use std::cmp::Ordering;
 use std::fmt;
 
 /// Process execution state.
@@ -65,14 +69,39 @@ impl PartialEq for Box<dyn ProcessHolder> {
     }
 }
 
+/// Maximum byte length for BigInt values (1024 bits = 128 bytes).
+pub const BIGINT_MAX_BYTES: usize = 128;
+
 /// Runtime value in RSpace.
 ///
 /// Values are the fundamental data type stored in RSpace channels,
 /// passed between processes, and returned from computations.
-#[derive(Clone, Debug, PartialEq)]
+///
+/// # Numeric types
+///
+/// Following the Rholang numeric types spec (Michael Stay, 2025-11-13):
+/// - `Int(i64)` — default signed 64-bit integers (unqualified literals)
+/// - `Float(f64)` — IEEE 754 double precision (suffix `f64`, also covers `f32`)
+/// - `BigInt(BigInt)` — arbitrary-precision signed integers (suffix `n`)
+/// - `BigRat(BigRational)` — exact rationals as ratio of bigints (suffix `r`)
+/// - `FixedPoint` — shifted bigints with fixed decimal scale (suffix `p<digits>`)
+///
+/// No implicit coercion between types. All binary ops require matching types.
+#[derive(Clone, Debug)]
 pub enum Value {
     /// 64-bit signed integer.
     Int(i64),
+    /// IEEE 754 double-precision float. NaN != NaN per IEEE 754.
+    Float(f64),
+    /// Arbitrary-precision signed integer (suffix `n`).
+    BigInt(BigInt),
+    /// Exact rational number as ratio of BigInts (suffix `r`).
+    BigRat(BigRational),
+    /// Fixed-point decimal: actual_value = unscaled / 10^scale (suffix `p<scale>`).
+    FixedPoint {
+        unscaled: BigInt,
+        scale: u32,
+    },
     /// Boolean value.
     Bool(bool),
     /// UTF-8 string.
@@ -92,9 +121,68 @@ pub enum Value {
     Nil,
 }
 
+/// Custom PartialEq: Float uses IEEE 754 semantics where NaN != NaN.
+impl PartialEq for Value {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Value::Int(a), Value::Int(b)) => a == b,
+            (Value::Float(a), Value::Float(b)) => a == b, // NaN != NaN per IEEE 754
+            (Value::BigInt(a), Value::BigInt(b)) => a == b,
+            (Value::BigRat(a), Value::BigRat(b)) => a == b,
+            (
+                Value::FixedPoint {
+                    unscaled: ua,
+                    scale: sa,
+                },
+                Value::FixedPoint {
+                    unscaled: ub,
+                    scale: sb,
+                },
+            ) => sa == sb && ua == ub,
+            (Value::Bool(a), Value::Bool(b)) => a == b,
+            (Value::Str(a), Value::Str(b)) => a == b,
+            (Value::Name(a), Value::Name(b)) => a == b,
+            (Value::List(a), Value::List(b)) => a == b,
+            (Value::Tuple(a), Value::Tuple(b)) => a == b,
+            (Value::Map(a), Value::Map(b)) => a == b,
+            (Value::Par(a), Value::Par(b)) => a == b,
+            (Value::Nil, Value::Nil) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialOrd for Value {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (Value::Int(a), Value::Int(b)) => Some(a.cmp(b)),
+            (Value::Float(a), Value::Float(b)) => a.partial_cmp(b), // NaN → None
+            (Value::BigInt(a), Value::BigInt(b)) => Some(a.cmp(b)),
+            (Value::BigRat(a), Value::BigRat(b)) => Some(a.cmp(b)),
+            (
+                Value::FixedPoint {
+                    unscaled: ua,
+                    scale: sa,
+                },
+                Value::FixedPoint {
+                    unscaled: ub,
+                    scale: sb,
+                },
+            ) => {
+                if sa != sb {
+                    None // cross-scale comparison not defined
+                } else {
+                    Some(ua.cmp(ub))
+                }
+            }
+            (Value::Str(a), Value::Str(b)) => Some(a.cmp(b)),
+            _ => None,
+        }
+    }
+}
+
 impl Value {
     /// Try to extract an integer value.
-    #[allow(dead_code)]
     pub fn as_int(&self) -> Option<i64> {
         if let Value::Int(n) = self {
             Some(*n)
@@ -103,8 +191,43 @@ impl Value {
         }
     }
 
+    /// Try to extract a float value.
+    pub fn as_float(&self) -> Option<f64> {
+        if let Value::Float(f) = self {
+            Some(*f)
+        } else {
+            None
+        }
+    }
+
+    /// Try to extract a BigInt reference.
+    pub fn as_bigint(&self) -> Option<&BigInt> {
+        if let Value::BigInt(n) = self {
+            Some(n)
+        } else {
+            None
+        }
+    }
+
+    /// Try to extract a BigRational reference.
+    pub fn as_bigrat(&self) -> Option<&BigRational> {
+        if let Value::BigRat(r) = self {
+            Some(r)
+        } else {
+            None
+        }
+    }
+
+    /// Try to extract a FixedPoint value.
+    pub fn as_fixed_point(&self) -> Option<(&BigInt, u32)> {
+        if let Value::FixedPoint { unscaled, scale } = self {
+            Some((unscaled, *scale))
+        } else {
+            None
+        }
+    }
+
     /// Try to extract a boolean value.
-    #[allow(dead_code)]
     pub fn as_bool(&self) -> Option<bool> {
         if let Value::Bool(b) = self {
             Some(*b)
@@ -114,7 +237,6 @@ impl Value {
     }
 
     /// Try to extract a string value.
-    #[allow(dead_code)]
     pub fn as_str(&self) -> Option<&str> {
         if let Value::Str(s) = self {
             Some(s)
@@ -122,11 +244,110 @@ impl Value {
             None
         }
     }
+
+    /// Returns the type name for error messages.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Value::Int(_) => "Int",
+            Value::Float(_) => "Float",
+            Value::BigInt(_) => "BigInt",
+            Value::BigRat(_) => "BigRat",
+            Value::FixedPoint { .. } => "FixedPoint",
+            Value::Bool(_) => "Bool",
+            Value::Str(_) => "Str",
+            Value::Name(_) => "Name",
+            Value::List(_) => "List",
+            Value::Tuple(_) => "Tuple",
+            Value::Map(_) => "Map",
+            Value::Par(_) => "Par",
+            Value::Nil => "Nil",
+        }
+    }
+
+    /// Check if a BigInt value exceeds the maximum allowed size.
+    pub fn check_bigint_size(n: &BigInt) -> Result<(), String> {
+        let byte_len = n.to_signed_bytes_be().len();
+        if byte_len > BIGINT_MAX_BYTES {
+            Err(format!(
+                "BigInt exceeds 1024-bit maximum ({} bytes, max {})",
+                byte_len, BIGINT_MAX_BYTES
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Create a BigRat value, returning zero for 0r.
+    pub fn new_bigrat(r: BigRational) -> Value {
+        Value::BigRat(r)
+    }
+
+    /// Create a BigRat zero.
+    pub fn bigrat_zero() -> Value {
+        Value::BigRat(BigRational::zero())
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Int(n) => write!(f, "{n}"),
+            Value::Float(v) => write!(f, "{v}f64"),
+            Value::BigInt(n) => write!(f, "{n}n"),
+            Value::BigRat(r) => {
+                if r.denom() == &BigInt::from(1) {
+                    write!(f, "{}r", r.numer())
+                } else {
+                    write!(f, "{}r/{}r", r.numer(), r.denom())
+                }
+            }
+            Value::FixedPoint { unscaled, scale } => {
+                let scale = *scale as usize;
+                if scale == 0 {
+                    return write!(f, "{unscaled}p0");
+                }
+                let (sign, abs) = if *unscaled < BigInt::ZERO {
+                    ("-", (-unscaled).to_string())
+                } else {
+                    ("", unscaled.to_string())
+                };
+                if abs.len() > scale {
+                    let (integer, frac) = abs.split_at(abs.len() - scale);
+                    write!(f, "{sign}{integer}.{frac}p{scale}")
+                } else {
+                    let padding = "0".repeat(scale - abs.len());
+                    write!(f, "{sign}0.{padding}{abs}p{scale}")
+                }
+            }
+            Value::Bool(b) => write!(f, "{b}"),
+            Value::Str(s) => write!(f, "\"{s}\""),
+            Value::Name(n) => write!(f, "@\"{n}\""),
+            Value::List(items) => {
+                let inner: Vec<String> = items.iter().map(|v| v.to_string()).collect();
+                write!(f, "[{}]", inner.join(", "))
+            }
+            Value::Tuple(items) => {
+                let inner: Vec<String> = items.iter().map(|v| v.to_string()).collect();
+                write!(f, "({})", inner.join(", "))
+            }
+            Value::Map(entries) => {
+                let inner: Vec<String> = entries
+                    .iter()
+                    .map(|(k, v)| format!("{k}: {v}"))
+                    .collect();
+                write!(f, "{{{}}}", inner.join(", "))
+            }
+            Value::Par(_) => write!(f, "<Par>"),
+            Value::Nil => write!(f, "Nil"),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use num_bigint::BigInt;
+    use num_rational::BigRational;
 
     #[test]
     fn test_value_as_int() {
@@ -134,6 +355,37 @@ mod tests {
         assert_eq!(Value::Bool(true).as_int(), None);
         assert_eq!(Value::Str("test".to_string()).as_int(), None);
         assert_eq!(Value::Nil.as_int(), None);
+    }
+
+    #[test]
+    fn test_value_as_float() {
+        assert_eq!(Value::Float(3.14).as_float(), Some(3.14));
+        assert_eq!(Value::Int(1).as_float(), None);
+    }
+
+    #[test]
+    fn test_value_as_bigint() {
+        let val = Value::BigInt(BigInt::from(42));
+        assert_eq!(val.as_bigint(), Some(&BigInt::from(42)));
+        assert_eq!(Value::Int(42).as_bigint(), None);
+    }
+
+    #[test]
+    fn test_value_as_bigrat() {
+        let r = BigRational::new(BigInt::from(1), BigInt::from(3));
+        let val = Value::BigRat(r.clone());
+        assert_eq!(val.as_bigrat(), Some(&r));
+        assert_eq!(Value::Int(1).as_bigrat(), None);
+    }
+
+    #[test]
+    fn test_value_as_fixed_point() {
+        let val = Value::FixedPoint {
+            unscaled: BigInt::from(33),
+            scale: 1,
+        };
+        assert_eq!(val.as_fixed_point(), Some((&BigInt::from(33), 1)));
+        assert_eq!(Value::Int(1).as_fixed_point(), None);
     }
 
     #[test]
@@ -157,6 +409,152 @@ mod tests {
             Value::Map(vec![(Value::Int(1), Value::Int(2))]),
             Value::Map(vec![(Value::Int(1), Value::Int(2))])
         );
+    }
+
+    #[test]
+    fn test_float_equality() {
+        assert_eq!(Value::Float(1.0), Value::Float(1.0));
+        assert_ne!(Value::Float(1.0), Value::Float(2.0));
+        // IEEE 754: positive and negative zero are equal
+        assert_eq!(Value::Float(0.0), Value::Float(-0.0));
+    }
+
+    #[test]
+    fn test_float_nan_equality() {
+        // IEEE 754: NaN != NaN
+        assert_ne!(Value::Float(f64::NAN), Value::Float(f64::NAN));
+        assert_ne!(Value::Float(f64::NAN), Value::Float(0.0));
+    }
+
+    #[test]
+    fn test_float_partial_ord() {
+        assert!(Value::Float(1.0) < Value::Float(2.0));
+        assert!(Value::Float(2.0) > Value::Float(1.0));
+        // NaN comparisons return None (not less, not greater, not equal)
+        assert_eq!(
+            Value::Float(f64::NAN).partial_cmp(&Value::Float(1.0)),
+            None
+        );
+        assert_eq!(
+            Value::Float(f64::NAN).partial_cmp(&Value::Float(f64::NAN)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_bigint_equality() {
+        assert_eq!(
+            Value::BigInt(BigInt::from(100)),
+            Value::BigInt(BigInt::from(100))
+        );
+        assert_ne!(
+            Value::BigInt(BigInt::from(100)),
+            Value::BigInt(BigInt::from(200))
+        );
+    }
+
+    #[test]
+    fn test_bigint_ordering() {
+        assert!(Value::BigInt(BigInt::from(1)) < Value::BigInt(BigInt::from(2)));
+        assert!(Value::BigInt(BigInt::from(-1)) < Value::BigInt(BigInt::from(0)));
+    }
+
+    #[test]
+    fn test_bigrat_equality() {
+        let half_a = BigRational::new(BigInt::from(1), BigInt::from(2));
+        let half_b = BigRational::new(BigInt::from(2), BigInt::from(4)); // auto-normalized to 1/2
+        assert_eq!(Value::BigRat(half_a), Value::BigRat(half_b));
+    }
+
+    #[test]
+    fn test_bigrat_ordering() {
+        let third = BigRational::new(BigInt::from(1), BigInt::from(3));
+        let half = BigRational::new(BigInt::from(1), BigInt::from(2));
+        assert!(Value::BigRat(third) < Value::BigRat(half));
+    }
+
+    #[test]
+    fn test_fixed_point_equality() {
+        let a = Value::FixedPoint {
+            unscaled: BigInt::from(33),
+            scale: 1,
+        };
+        let b = Value::FixedPoint {
+            unscaled: BigInt::from(33),
+            scale: 1,
+        };
+        assert_eq!(a, b);
+
+        // Different scale = not equal (even if mathematically equivalent)
+        let c = Value::FixedPoint {
+            unscaled: BigInt::from(330),
+            scale: 2,
+        };
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_fixed_point_ordering() {
+        // Same scale: compare by unscaled
+        let a = Value::FixedPoint {
+            unscaled: BigInt::from(10),
+            scale: 1,
+        };
+        let b = Value::FixedPoint {
+            unscaled: BigInt::from(20),
+            scale: 1,
+        };
+        assert!(a < b);
+
+        // Different scale: not comparable
+        let c = Value::FixedPoint {
+            unscaled: BigInt::from(10),
+            scale: 2,
+        };
+        assert_eq!(a.partial_cmp(&c), None);
+    }
+
+    #[test]
+    fn test_cross_type_not_equal() {
+        assert_ne!(Value::Int(1), Value::Float(1.0));
+        assert_ne!(Value::Int(1), Value::BigInt(BigInt::from(1)));
+        assert_ne!(Value::Float(1.0), Value::BigRat(BigRational::from(BigInt::from(1))));
+    }
+
+    #[test]
+    fn test_cross_type_not_comparable() {
+        assert_eq!(Value::Int(1).partial_cmp(&Value::Float(1.0)), None);
+        assert_eq!(
+            Value::Int(1).partial_cmp(&Value::BigInt(BigInt::from(1))),
+            None
+        );
+    }
+
+    #[test]
+    fn test_bigint_size_check() {
+        // Small value: ok
+        assert!(Value::check_bigint_size(&BigInt::from(42)).is_ok());
+
+        // Value that fits in 128 bytes: ok
+        // Max positive value in 128 bytes signed = 2^1023 - 1
+        let max_val = (BigInt::from(1) << 1023) - 1;
+        assert!(Value::check_bigint_size(&max_val).is_ok());
+
+        // 1 << 1023 requires 129 bytes in signed two's complement (leading 0x00 byte)
+        let over_val = BigInt::from(1) << 1023;
+        assert!(Value::check_bigint_size(&over_val).is_err());
+
+        // ETH uint256 max (2^256 - 1): fits easily within 128 bytes
+        let eth_max = (BigInt::from(1) << 256) - 1;
+        assert!(Value::check_bigint_size(&eth_max).is_ok());
+    }
+
+    #[test]
+    fn test_type_name() {
+        assert_eq!(Value::Int(1).type_name(), "Int");
+        assert_eq!(Value::Float(1.0).type_name(), "Float");
+        assert_eq!(Value::BigInt(BigInt::from(1)).type_name(), "BigInt");
+        assert_eq!(Value::Nil.type_name(), "Nil");
     }
 
     #[test]
@@ -187,5 +585,43 @@ mod tests {
             ProcessState::Error("e".into()),
             ProcessState::Error("e".into())
         );
+    }
+
+    // =========================================================================
+    // Display formatting
+    // =========================================================================
+
+    #[test]
+    fn test_display_numeric_types() {
+        assert_eq!(Value::Int(42).to_string(), "42");
+        assert_eq!(Value::Int(-7).to_string(), "-7");
+        assert_eq!(Value::Float(3.14).to_string(), "3.14f64");
+        assert_eq!(Value::BigInt(BigInt::from(100)).to_string(), "100n");
+        assert_eq!(Value::BigInt(BigInt::from(-42)).to_string(), "-42n");
+
+        let whole = BigRational::new(BigInt::from(5), BigInt::from(1));
+        assert_eq!(Value::BigRat(whole).to_string(), "5r");
+        let frac = BigRational::new(BigInt::from(1), BigInt::from(3));
+        assert_eq!(Value::BigRat(frac).to_string(), "1r/3r");
+    }
+
+    #[test]
+    fn test_display_fixedpoint_edge_cases() {
+        let fp = |u: i64, s: u32| Value::FixedPoint { unscaled: BigInt::from(u), scale: s };
+        assert_eq!(fp(150, 2).to_string(), "1.50p2");
+        assert_eq!(fp(42, 0).to_string(), "42p0");
+        assert_eq!(fp(3, 2).to_string(), "0.03p2");       // small positive
+        assert_eq!(fp(-150, 2).to_string(), "-1.50p2");    // negative
+        assert_eq!(fp(-3, 2).to_string(), "-0.03p2");      // negative small (was buggy)
+    }
+
+    #[test]
+    fn test_display_non_numeric_types() {
+        assert_eq!(Value::Bool(true).to_string(), "true");
+        assert_eq!(Value::Str("hello".into()).to_string(), "\"hello\"");
+        assert_eq!(Value::Name("ch".into()).to_string(), "@\"ch\"");
+        assert_eq!(Value::Nil.to_string(), "Nil");
+        assert_eq!(Value::List(vec![Value::Int(1), Value::Int(2)]).to_string(), "[1, 2]");
+        assert_eq!(Value::Tuple(vec![Value::Int(1), Value::Bool(true)]).to_string(), "(1, true)");
     }
 }

--- a/rholang-shell/src/bin/core_rholang_examples.rs
+++ b/rholang-shell/src/bin/core_rholang_examples.rs
@@ -189,30 +189,11 @@ pub fn compile_and_run(source: &str) -> Result<Value> {
 /// Format a Value for display
 pub fn format_value(v: &Value) -> String {
     match v {
-        Value::Nil => "Nil".to_string(),
-        Value::Int(i) => i.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Str(s) => format!("\"{}\"", s),
-        Value::List(items) => {
-            let inner: Vec<String> = items.iter().map(format_value).collect();
-            format!("[{}]", inner.join(", "))
-        }
-        Value::Tuple(items) => {
-            let inner: Vec<String> = items.iter().map(format_value).collect();
-            format!("({})", inner.join(", "))
-        }
-        Value::Name(n) => format!("@\"{}\"", n),
-        Value::Map(m) => {
-            let inner: Vec<String> = m
-                .iter()
-                .map(|(k, v)| format!("{}: {}", format_value(k), format_value(v)))
-                .collect();
-            format!("{{{}}}", inner.join(", "))
-        }
         Value::Par(ps) => {
             let inner: Vec<String> = ps.iter().map(|p| format!("<{}>", p.source_ref())).collect();
             inner.join(" | ")
         }
+        other => other.to_string(),
     }
 }
 

--- a/rholang-shell/src/providers.rs
+++ b/rholang-shell/src/providers.rs
@@ -489,25 +489,6 @@ impl RholangCompilerInterpreterProvider {
 
     fn render_value(v: &VmValue) -> String {
         match v {
-            VmValue::Int(n) => n.to_string(),
-            VmValue::Bool(b) => b.to_string(),
-            VmValue::Str(s) => format!("\"{}\"", s),
-            VmValue::Name(n) => format!("@{}", n),
-            VmValue::List(items) => {
-                let inner: Vec<String> = items.iter().map(Self::render_value).collect();
-                format!("[{}]", inner.join(", "))
-            }
-            VmValue::Tuple(items) => {
-                let inner: Vec<String> = items.iter().map(Self::render_value).collect();
-                format!("({})", inner.join(", "))
-            }
-            VmValue::Map(entries) => {
-                let inner: Vec<String> = entries
-                    .iter()
-                    .map(|(k, v)| format!("{}: {}", Self::render_value(k), Self::render_value(v)))
-                    .collect();
-                format!("{{{}}}", inner.join(", "))
-            }
             VmValue::Par(procs) => {
                 let inner: Vec<String> = procs
                     .iter()
@@ -515,7 +496,7 @@ impl RholangCompilerInterpreterProvider {
                     .collect();
                 inner.join(" | ")
             }
-            VmValue::Nil => "Nil".to_string(),
+            other => other.to_string(),
         }
     }
 }

--- a/rholang-vm/Cargo.toml
+++ b/rholang-vm/Cargo.toml
@@ -6,6 +6,10 @@ description = "Rholang VM execution engine based on rholang-bytecode"
 
 [dependencies]
 anyhow = { workspace = true }
+num-bigint = { workspace = true }
+num-rational = { workspace = true }
+num-traits = { workspace = true }
+num-integer = { workspace = true }
 rholang-bytecode = { path = "../rholang-bytecode" }
 # Core types from rholang-rspace (without pathmap feature to avoid circular dep)
 rholang-rspace = { path = "../rholang-rspace", default-features = false }

--- a/rholang-vm/src/execute.rs
+++ b/rholang-vm/src/execute.rs
@@ -1,9 +1,13 @@
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::Zero;
 use rholang_bytecode::core::instructions::Instruction as CoreInst;
 use rholang_bytecode::core::opcodes::Opcode;
+use std::cmp::Ordering;
 use std::result::Result;
 
 use crate::VM;
-use rholang_rspace::{ExecError, Value};
+use rholang_rspace::{ExecError, Value, BIGINT_MAX_BYTES};
 
 pub enum StepResult {
     Next,
@@ -19,11 +23,13 @@ pub enum StepResult {
 /// * `vm` - The VM state (stack, rspace, continuations, name counter)
 /// * `locals` - The process's local variable slots
 /// * `names` - The process's string pool for PUSH_STR
+/// * `constants` - The process's typed constant pool for PUSH_CONST
 /// * `inst` - The instruction to execute
 pub fn step(
     vm: &mut VM,
     locals: &mut Vec<Value>,
     names: &[Value],
+    constants: &[Value],
     inst: CoreInst,
 ) -> Result<StepResult, ExecError> {
     let opcode = inst.opcode().map_err(|e| ExecError::OpcodeParamError {
@@ -62,6 +68,18 @@ pub fn step(
             }
         }
         Opcode::PUSH_NIL => vm.stack.push(Value::Nil),
+        Opcode::PUSH_CONST => {
+            let idx = inst.op16() as usize;
+            match constants.get(idx) {
+                Some(val) => vm.stack.push(val.clone()),
+                None => {
+                    return Err(ExecError::OpcodeParamError {
+                        opcode: "PUSH_CONST",
+                        message: format!("constants index out of bounds: {}", idx),
+                    });
+                }
+            }
+        }
         Opcode::POP => {
             let _ = vm.stack.pop();
         }
@@ -70,42 +88,86 @@ pub fn step(
         Opcode::ADD => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
             match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a + b)),
+                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a.wrapping_add(b))),
+                (Some(Value::Float(a)), Some(Value::Float(b))) => vm.stack.push(Value::Float(a + b)),
+                (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
+                    let r = a + b;
+                    check_bigint_size("ADD", &r)?;
+                    vm.stack.push(Value::BigInt(r));
+                }
+                (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
+                    let r = a + b;
+                    check_bigrat_size("ADD", &r)?;
+                    vm.stack.push(Value::BigRat(r));
+                }
+                (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
+                    if sa != sb {
+                        return Err(type_mismatch_error("ADD", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
+                    }
+                    let r = ua + ub;
+                    check_bigint_size("ADD", &r)?;
+                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                }
                 (Some(Value::Str(a)), Some(Value::Str(b))) => vm.stack.push(Value::Str(a + &b)),
                 (Some(Value::List(mut a)), Some(Value::List(b))) => {
                     a.extend(b);
                     vm.stack.push(Value::List(a));
                 }
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "ADD",
-                        message: "type mismatch".to_string(),
-                    })
-                }
+                (Some(a), Some(b)) => return Err(type_mismatch_error("ADD", a.type_name(), b.type_name())),
+                _ => return Err(stack_underflow("ADD")),
             }
         }
         Opcode::SUB => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
             match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a - b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "SUB",
-                        message: "requires Ints".to_string(),
-                    })
+                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a.wrapping_sub(b))),
+                (Some(Value::Float(a)), Some(Value::Float(b))) => vm.stack.push(Value::Float(a - b)),
+                (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
+                    let r = a - b;
+                    check_bigint_size("SUB", &r)?;
+                    vm.stack.push(Value::BigInt(r));
                 }
+                (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
+                    let r = a - b;
+                    check_bigrat_size("SUB", &r)?;
+                    vm.stack.push(Value::BigRat(r));
+                }
+                (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
+                    if sa != sb {
+                        return Err(type_mismatch_error("SUB", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
+                    }
+                    let r = ua - ub;
+                    check_bigint_size("SUB", &r)?;
+                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                }
+                (Some(a), Some(b)) => return Err(type_mismatch_error("SUB", a.type_name(), b.type_name())),
+                _ => return Err(stack_underflow("SUB")),
             }
         }
         Opcode::MUL => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
             match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a * b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "MUL",
-                        message: "requires Ints".to_string(),
-                    })
+                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a.wrapping_mul(b))),
+                (Some(Value::Float(a)), Some(Value::Float(b))) => vm.stack.push(Value::Float(a * b)),
+                (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
+                    let r = a * b;
+                    check_bigint_size("MUL", &r)?;
+                    vm.stack.push(Value::BigInt(r));
                 }
+                (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
+                    let r = a * b;
+                    check_bigrat_size("MUL", &r)?;
+                    vm.stack.push(Value::BigRat(r));
+                }
+                (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
+                    // Scale doubles: p1 * p1 → p2
+                    let r = ua * ub;
+                    let new_scale = sa + sb;
+                    check_bigint_size("MUL", &r)?;
+                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: new_scale });
+                }
+                (Some(a), Some(b)) => return Err(type_mismatch_error("MUL", a.type_name(), b.type_name())),
+                _ => return Err(stack_underflow("MUL")),
             }
         }
         Opcode::DIV => {
@@ -113,19 +175,44 @@ pub fn step(
             match (a, b) {
                 (Some(Value::Int(a)), Some(Value::Int(b))) => {
                     if b == 0 {
-                        return Err(ExecError::OpcodeParamError {
-                            opcode: "DIV",
-                            message: "division by zero".to_string(),
-                        });
+                        return Err(div_by_zero("DIV"));
                     }
-                    vm.stack.push(Value::Int(a / b))
+                    vm.stack.push(Value::Int(a.wrapping_div(b)));
                 }
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "DIV",
-                        message: "requires Ints".to_string(),
-                    })
+                (Some(Value::Float(a)), Some(Value::Float(b))) => {
+                    // IEEE 754: div by zero produces Inf/-Inf/NaN
+                    vm.stack.push(Value::Float(a / b));
                 }
+                (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
+                    if b.is_zero() {
+                        return Err(div_by_zero("DIV"));
+                    }
+                    let r = a / b;
+                    vm.stack.push(Value::BigInt(r));
+                }
+                (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
+                    if b.is_zero() {
+                        return Err(div_by_zero("DIV"));
+                    }
+                    let r = a / b;
+                    check_bigrat_size("DIV", &r)?;
+                    vm.stack.push(Value::BigRat(r));
+                }
+                (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
+                    if sa != sb {
+                        return Err(type_mismatch_error("DIV", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
+                    }
+                    if ub.is_zero() {
+                        return Err(div_by_zero("DIV"));
+                    }
+                    // Shifted division: (ua * 10^scale) / ub
+                    let shifted = ua * num_traits::pow::pow(BigInt::from(10), sa as usize);
+                    let r = shifted / ub;
+                    check_bigint_size("DIV", &r)?;
+                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                }
+                (Some(a), Some(b)) => return Err(type_mismatch_error("DIV", a.type_name(), b.type_name())),
+                _ => return Err(stack_underflow("DIV")),
             }
         }
         Opcode::MOD => {
@@ -133,29 +220,61 @@ pub fn step(
             match (a, b) {
                 (Some(Value::Int(a)), Some(Value::Int(b))) => {
                     if b == 0 {
-                        return Err(ExecError::OpcodeParamError {
-                            opcode: "MOD",
-                            message: "modulo by zero".to_string(),
-                        });
+                        return Err(div_by_zero("MOD"));
                     }
-                    vm.stack.push(Value::Int(a % b))
+                    vm.stack.push(Value::Int(a % b));
                 }
-                _ => {
+                (Some(Value::Float(_)), Some(Value::Float(_))) => {
                     return Err(ExecError::OpcodeParamError {
                         opcode: "MOD",
-                        message: "requires Ints".to_string(),
-                    })
+                        message: "modulus not defined on floating point".to_string(),
+                    });
                 }
+                (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
+                    if b.is_zero() {
+                        return Err(div_by_zero("MOD"));
+                    }
+                    let r = a % b;
+                    vm.stack.push(Value::BigInt(r));
+                }
+                (Some(Value::BigRat(_)), Some(Value::BigRat(_))) => {
+                    // Per spec: (a/b)*b == a exactly, so mod always returns 0
+                    vm.stack.push(Value::BigRat(BigRational::zero()));
+                }
+                (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
+                    if sa != sb {
+                        return Err(type_mismatch_error("MOD", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
+                    }
+                    if ub.is_zero() {
+                        return Err(div_by_zero("MOD"));
+                    }
+                    // C99 identity: (a/b)*b + a%b == a
+                    // quotient = (ua * 10^scale) / ub (same as DIV)
+                    // remainder = ua - quotient * ub
+                    let scale_factor = num_traits::pow::pow(BigInt::from(10), sa as usize);
+                    let quotient = (&ua * &scale_factor) / &ub;
+                    let r = ua - (&quotient * &ub) / scale_factor;
+                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                }
+                (Some(a), Some(b)) => return Err(type_mismatch_error("MOD", a.type_name(), b.type_name())),
+                _ => return Err(stack_underflow("MOD")),
             }
         }
         Opcode::NEG => match vm.stack.pop() {
-            Some(Value::Int(a)) => vm.stack.push(Value::Int(-a)),
-            _ => {
+            Some(Value::Int(a)) => vm.stack.push(Value::Int(a.wrapping_neg())),
+            Some(Value::Float(a)) => vm.stack.push(Value::Float(-a)),
+            Some(Value::BigInt(a)) => vm.stack.push(Value::BigInt(-a)),
+            Some(Value::BigRat(a)) => vm.stack.push(Value::BigRat(-a)),
+            Some(Value::FixedPoint { unscaled, scale }) => {
+                vm.stack.push(Value::FixedPoint { unscaled: -unscaled, scale });
+            }
+            Some(other) => {
                 return Err(ExecError::OpcodeParamError {
                     opcode: "NEG",
-                    message: "requires Int".to_string(),
-                })
+                    message: format!("cannot negate {}", other.type_name()),
+                });
             }
+            None => return Err(stack_underflow("NEG")),
         },
 
         // Comparison
@@ -163,73 +282,31 @@ pub fn step(
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
             match (a, b) {
                 (Some(a), Some(b)) => vm.stack.push(Value::Bool(a == b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "CMP_EQ",
-                        message: "requires two values".to_string(),
-                    })
-                }
+                _ => return Err(stack_underflow("CMP_EQ")),
             }
         }
         Opcode::CMP_NEQ => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
             match (a, b) {
                 (Some(a), Some(b)) => vm.stack.push(Value::Bool(a != b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "CMP_NEQ",
-                        message: "requires two values".to_string(),
-                    })
-                }
+                _ => return Err(stack_underflow("CMP_NEQ")),
             }
         }
         Opcode::CMP_LT => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
-            match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Bool(a < b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "CMP_LT",
-                        message: "requires Ints".to_string(),
-                    })
-                }
-            }
+            vm.stack.push(Value::Bool(compare_values("CMP_LT", &a, &b)? == Ordering::Less));
         }
         Opcode::CMP_LTE => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
-            match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Bool(a <= b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "CMP_LTE",
-                        message: "requires Ints".to_string(),
-                    })
-                }
-            }
+            vm.stack.push(Value::Bool(matches!(compare_values("CMP_LTE", &a, &b)?, Ordering::Less | Ordering::Equal)));
         }
         Opcode::CMP_GT => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
-            match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Bool(a > b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "CMP_GT",
-                        message: "requires Ints".to_string(),
-                    })
-                }
-            }
+            vm.stack.push(Value::Bool(compare_values("CMP_GT", &a, &b)? == Ordering::Greater));
         }
         Opcode::CMP_GTE => {
             let (b, a) = (vm.stack.pop(), vm.stack.pop());
-            match (a, b) {
-                (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Bool(a >= b)),
-                _ => {
-                    return Err(ExecError::OpcodeParamError {
-                        opcode: "CMP_GTE",
-                        message: "requires Ints".to_string(),
-                    })
-                }
-            }
+            vm.stack.push(Value::Bool(matches!(compare_values("CMP_GTE", &a, &b)?, Ordering::Greater | Ordering::Equal)));
         }
 
         // Logical operators
@@ -616,4 +693,77 @@ pub fn step(
     }
 
     Ok(StepResult::Next)
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions for arithmetic/comparison opcodes
+// ---------------------------------------------------------------------------
+
+fn check_bigint_size(opcode: &'static str, n: &BigInt) -> Result<(), ExecError> {
+    if n.to_signed_bytes_be().len() > BIGINT_MAX_BYTES {
+        return Err(ExecError::OpcodeParamError {
+            opcode,
+            message: format!(
+                "BigInt result exceeds {} byte limit",
+                BIGINT_MAX_BYTES
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn check_bigrat_size(opcode: &'static str, r: &BigRational) -> Result<(), ExecError> {
+    let numer_bytes = r.numer().to_signed_bytes_be().len();
+    let denom_bytes = r.denom().to_signed_bytes_be().len();
+    if numer_bytes > BIGINT_MAX_BYTES || denom_bytes > BIGINT_MAX_BYTES {
+        return Err(ExecError::OpcodeParamError {
+            opcode,
+            message: format!(
+                "BigRat component exceeds {} byte limit (numer: {} bytes, denom: {} bytes)",
+                BIGINT_MAX_BYTES, numer_bytes, denom_bytes
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn type_mismatch_error(opcode: &'static str, type_a: &str, type_b: &str) -> ExecError {
+    ExecError::OpcodeParamError {
+        opcode,
+        message: format!("type mismatch: {} vs {}", type_a, type_b),
+    }
+}
+
+fn stack_underflow(opcode: &'static str) -> ExecError {
+    ExecError::OpcodeParamError {
+        opcode,
+        message: "stack underflow".to_string(),
+    }
+}
+
+fn div_by_zero(opcode: &'static str) -> ExecError {
+    ExecError::OpcodeParamError {
+        opcode,
+        message: "division by zero".to_string(),
+    }
+}
+
+fn compare_values(
+    opcode: &'static str,
+    a: &Option<Value>,
+    b: &Option<Value>,
+) -> Result<Ordering, ExecError> {
+    match (a, b) {
+        (Some(a_val), Some(b_val)) => a_val
+            .partial_cmp(b_val)
+            .ok_or_else(|| ExecError::OpcodeParamError {
+                opcode,
+                message: format!(
+                    "values not comparable: {} vs {}",
+                    a_val.type_name(),
+                    b_val.type_name()
+                ),
+            }),
+        _ => Err(stack_underflow(opcode)),
+    }
 }

--- a/rholang-vm/src/execute.rs
+++ b/rholang-vm/src/execute.rs
@@ -1,13 +1,13 @@
 use num_bigint::BigInt;
 use num_rational::BigRational;
-use num_traits::Zero;
+use num_traits::{Signed, Zero};
 use rholang_bytecode::core::instructions::Instruction as CoreInst;
 use rholang_bytecode::core::opcodes::Opcode;
 use std::cmp::Ordering;
 use std::result::Result;
 
 use crate::VM;
-use rholang_rspace::{ExecError, Value, BIGINT_MAX_BYTES};
+use rholang_rspace::{ExecError, Value};
 
 pub enum StepResult {
     Next,
@@ -91,22 +91,16 @@ pub fn step(
                 (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a.wrapping_add(b))),
                 (Some(Value::Float(a)), Some(Value::Float(b))) => vm.stack.push(Value::Float(a + b)),
                 (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
-                    let r = a + b;
-                    check_bigint_size("ADD", &r)?;
-                    vm.stack.push(Value::BigInt(r));
+                    vm.stack.push(Value::BigInt(a + b));
                 }
                 (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
-                    let r = a + b;
-                    check_bigrat_size("ADD", &r)?;
-                    vm.stack.push(Value::BigRat(r));
+                    vm.stack.push(Value::BigRat(a + b));
                 }
                 (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
                     if sa != sb {
                         return Err(type_mismatch_error("ADD", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
                     }
-                    let r = ua + ub;
-                    check_bigint_size("ADD", &r)?;
-                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                    vm.stack.push(Value::FixedPoint { unscaled: ua + ub, scale: sa });
                 }
                 (Some(Value::Str(a)), Some(Value::Str(b))) => vm.stack.push(Value::Str(a + &b)),
                 (Some(Value::List(mut a)), Some(Value::List(b))) => {
@@ -123,22 +117,16 @@ pub fn step(
                 (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a.wrapping_sub(b))),
                 (Some(Value::Float(a)), Some(Value::Float(b))) => vm.stack.push(Value::Float(a - b)),
                 (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
-                    let r = a - b;
-                    check_bigint_size("SUB", &r)?;
-                    vm.stack.push(Value::BigInt(r));
+                    vm.stack.push(Value::BigInt(a - b));
                 }
                 (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
-                    let r = a - b;
-                    check_bigrat_size("SUB", &r)?;
-                    vm.stack.push(Value::BigRat(r));
+                    vm.stack.push(Value::BigRat(a - b));
                 }
                 (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
                     if sa != sb {
                         return Err(type_mismatch_error("SUB", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
                     }
-                    let r = ua - ub;
-                    check_bigint_size("SUB", &r)?;
-                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                    vm.stack.push(Value::FixedPoint { unscaled: ua - ub, scale: sa });
                 }
                 (Some(a), Some(b)) => return Err(type_mismatch_error("SUB", a.type_name(), b.type_name())),
                 _ => return Err(stack_underflow("SUB")),
@@ -150,21 +138,27 @@ pub fn step(
                 (Some(Value::Int(a)), Some(Value::Int(b))) => vm.stack.push(Value::Int(a.wrapping_mul(b))),
                 (Some(Value::Float(a)), Some(Value::Float(b))) => vm.stack.push(Value::Float(a * b)),
                 (Some(Value::BigInt(a)), Some(Value::BigInt(b))) => {
-                    let r = a * b;
-                    check_bigint_size("MUL", &r)?;
-                    vm.stack.push(Value::BigInt(r));
+                    vm.stack.push(Value::BigInt(a * b));
                 }
                 (Some(Value::BigRat(a)), Some(Value::BigRat(b))) => {
-                    let r = a * b;
-                    check_bigrat_size("MUL", &r)?;
-                    vm.stack.push(Value::BigRat(r));
+                    vm.stack.push(Value::BigRat(a * b));
                 }
                 (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
-                    // Scale doubles: p1 * p1 → p2
-                    let r = ua * ub;
-                    let new_scale = sa + sb;
-                    check_bigint_size("MUL", &r)?;
-                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: new_scale });
+                    if sa != sb {
+                        return Err(type_mismatch_error("MUL", &format!("FixedPoint(p{})", sa), &format!("FixedPoint(p{})", sb)));
+                    }
+                    // Scale-preserving: (ua * ub) / 10^scale, using floor division
+                    let raw = &ua * &ub;
+                    let scale_factor = num_traits::pow::pow(BigInt::from(10), sa as usize);
+                    let one = BigInt::from(1);
+                    let unscaled: BigInt = if raw.is_negative() {
+                        // Floor division for negative: -((-raw - 1) / sf + 1)
+                        let abs_raw = -&raw;
+                        -((&abs_raw - &one) / &scale_factor + &one)
+                    } else {
+                        &raw / &scale_factor
+                    };
+                    vm.stack.push(Value::FixedPoint { unscaled, scale: sa });
                 }
                 (Some(a), Some(b)) => return Err(type_mismatch_error("MUL", a.type_name(), b.type_name())),
                 _ => return Err(stack_underflow("MUL")),
@@ -194,9 +188,7 @@ pub fn step(
                     if b.is_zero() {
                         return Err(div_by_zero("DIV"));
                     }
-                    let r = a / b;
-                    check_bigrat_size("DIV", &r)?;
-                    vm.stack.push(Value::BigRat(r));
+                    vm.stack.push(Value::BigRat(a / b));
                 }
                 (Some(Value::FixedPoint { unscaled: ua, scale: sa }), Some(Value::FixedPoint { unscaled: ub, scale: sb })) => {
                     if sa != sb {
@@ -207,9 +199,7 @@ pub fn step(
                     }
                     // Shifted division: (ua * 10^scale) / ub
                     let shifted = ua * num_traits::pow::pow(BigInt::from(10), sa as usize);
-                    let r = shifted / ub;
-                    check_bigint_size("DIV", &r)?;
-                    vm.stack.push(Value::FixedPoint { unscaled: r, scale: sa });
+                    vm.stack.push(Value::FixedPoint { unscaled: shifted / ub, scale: sa });
                 }
                 (Some(a), Some(b)) => return Err(type_mismatch_error("DIV", a.type_name(), b.type_name())),
                 _ => return Err(stack_underflow("DIV")),
@@ -698,34 +688,6 @@ pub fn step(
 // ---------------------------------------------------------------------------
 // Helper functions for arithmetic/comparison opcodes
 // ---------------------------------------------------------------------------
-
-fn check_bigint_size(opcode: &'static str, n: &BigInt) -> Result<(), ExecError> {
-    if n.to_signed_bytes_be().len() > BIGINT_MAX_BYTES {
-        return Err(ExecError::OpcodeParamError {
-            opcode,
-            message: format!(
-                "BigInt result exceeds {} byte limit",
-                BIGINT_MAX_BYTES
-            ),
-        });
-    }
-    Ok(())
-}
-
-fn check_bigrat_size(opcode: &'static str, r: &BigRational) -> Result<(), ExecError> {
-    let numer_bytes = r.numer().to_signed_bytes_be().len();
-    let denom_bytes = r.denom().to_signed_bytes_be().len();
-    if numer_bytes > BIGINT_MAX_BYTES || denom_bytes > BIGINT_MAX_BYTES {
-        return Err(ExecError::OpcodeParamError {
-            opcode,
-            message: format!(
-                "BigRat component exceeds {} byte limit (numer: {} bytes, denom: {} bytes)",
-                BIGINT_MAX_BYTES, numer_bytes, denom_bytes
-            ),
-        });
-    }
-    Ok(())
-}
 
 fn type_mismatch_error(opcode: &'static str, type_a: &str, type_b: &str) -> ExecError {
     ExecError::OpcodeParamError {

--- a/rholang-vm/src/vm.rs
+++ b/rholang-vm/src/vm.rs
@@ -126,6 +126,7 @@ impl VM {
     ///
     /// * `locals` - Process local variable slots
     /// * `names` - Process string pool for PUSH_STR
+    /// * `constants` - Typed constant pool for PUSH_CONST (numeric values)
     /// * `inst` - The instruction to execute
     ///
     /// # Returns
@@ -135,9 +136,10 @@ impl VM {
         &mut self,
         locals: &mut Vec<Value>,
         names: &[Value],
+        constants: &[Value],
         inst: CoreInst,
     ) -> Result<StepResult, ExecError> {
-        execute::step(self, locals, names, inst)
+        execute::step(self, locals, names, constants, inst)
     }
 }
 

--- a/rholang-vm/tests/arithmetic_tests.rs
+++ b/rholang-vm/tests/arithmetic_tests.rs
@@ -49,5 +49,5 @@ fn test_div_mod_by_zero_errors() {
     ];
     let mut process4 = Process::new(prog2, "arithmetic");
     let err2 = process4.execute().expect_err("should error mod by zero");
-    assert!(err2.to_string().to_lowercase().contains("modulo by zero"));
+    assert!(err2.to_string().to_lowercase().contains("division by zero"));
 }

--- a/rholang-vm/tests/comparison_tests.rs
+++ b/rholang-vm/tests/comparison_tests.rs
@@ -200,5 +200,5 @@ fn test_relational_ops_type_errors_and_underflow() {
         .execute()
         .expect_err("should error for underflow on CMP_GT");
     let msg2 = err2.to_string().to_lowercase();
-    assert!(msg2.contains("cmp_gt") && msg2.contains("int"));
+    assert!(msg2.contains("cmp_gt") && msg2.contains("stack underflow"));
 }

--- a/rholang-vm/tests/numeric_types_tests.rs
+++ b/rholang-vm/tests/numeric_types_tests.rs
@@ -1,0 +1,207 @@
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use rholang_process::Process;
+use rholang_vm::api::{Instruction, Opcode, Value};
+
+fn run_with_constants(prog: Vec<Instruction>, constants: Vec<Value>) -> Result<Value, String> {
+    let mut process = Process::new(prog, "numeric_test");
+    process.constants = constants;
+    process.execute().map_err(|e| e.to_string())
+}
+
+fn bigrat(numer: i64, denom: i64) -> Value {
+    Value::BigRat(BigRational::new(BigInt::from(numer), BigInt::from(denom)))
+}
+
+fn fixed(unscaled: i64, scale: u32) -> Value {
+    Value::FixedPoint {
+        unscaled: BigInt::from(unscaled),
+        scale,
+    }
+}
+
+/// Binary op helper: push two constants, apply opcode, return result.
+fn binop(a: Value, b: Value, op: Opcode) -> Result<Value, String> {
+    run_with_constants(
+        vec![
+            Instruction::unary(Opcode::PUSH_CONST, 0),
+            Instruction::unary(Opcode::PUSH_CONST, 1),
+            Instruction::nullary(op),
+            Instruction::nullary(Opcode::HALT),
+        ],
+        vec![a, b],
+    )
+}
+
+/// Binary op that should error.
+fn binop_err(a: Value, b: Value, op: Opcode) -> String {
+    run_with_constants(
+        vec![
+            Instruction::unary(Opcode::PUSH_CONST, 0),
+            Instruction::unary(Opcode::PUSH_CONST, 1),
+            Instruction::nullary(op),
+        ],
+        vec![a, b],
+    )
+    .unwrap_err()
+}
+
+/// Unary op helper.
+fn unaryop(a: Value, op: Opcode) -> Result<Value, String> {
+    run_with_constants(
+        vec![
+            Instruction::unary(Opcode::PUSH_CONST, 0),
+            Instruction::nullary(op),
+            Instruction::nullary(Opcode::HALT),
+        ],
+        vec![a],
+    )
+}
+
+// ==========================================================================
+// Float: arithmetic, IEEE 754 edge cases, NaN semantics
+// ==========================================================================
+
+#[test]
+fn test_float_arithmetic() {
+    assert_eq!(binop(Value::Float(1.5), Value::Float(2.25), Opcode::ADD).unwrap(), Value::Float(3.75));
+    assert_eq!(binop(Value::Float(5.0), Value::Float(3.0), Opcode::SUB).unwrap(), Value::Float(2.0));
+    assert_eq!(binop(Value::Float(2.5), Value::Float(4.0), Opcode::MUL).unwrap(), Value::Float(10.0));
+    assert_eq!(binop(Value::Float(10.0), Value::Float(4.0), Opcode::DIV).unwrap(), Value::Float(2.5));
+    assert_eq!(unaryop(Value::Float(3.14), Opcode::NEG).unwrap(), Value::Float(-3.14));
+}
+
+#[test]
+fn test_float_ieee754_edge_cases() {
+    // div by zero -> Inf (IEEE 754, not an error)
+    assert_eq!(binop(Value::Float(1.0), Value::Float(0.0), Opcode::DIV).unwrap(), Value::Float(f64::INFINITY));
+    // MOD on float is an error per spec
+    assert!(binop_err(Value::Float(5.0), Value::Float(3.0), Opcode::MOD).contains("not defined on floating point"));
+}
+
+#[test]
+fn test_float_nan_semantics() {
+    // NaN != NaN (IEEE 754)
+    assert_eq!(binop(Value::Float(f64::NAN), Value::Float(f64::NAN), Opcode::CMP_EQ).unwrap(), Value::Bool(false));
+    assert_eq!(binop(Value::Float(f64::NAN), Value::Float(f64::NAN), Opcode::CMP_NEQ).unwrap(), Value::Bool(true));
+    // NaN ordering is undefined -> error
+    assert!(binop_err(Value::Float(f64::NAN), Value::Float(1.0), Opcode::CMP_LT).contains("not comparable"));
+}
+
+#[test]
+fn test_float_comparison() {
+    assert_eq!(binop(Value::Float(1.5), Value::Float(2.5), Opcode::CMP_LT).unwrap(), Value::Bool(true));
+}
+
+// ==========================================================================
+// BigInt: arithmetic, overflow, comparison
+// ==========================================================================
+
+#[test]
+fn test_bigint_arithmetic() {
+    let bi = |n: i64| Value::BigInt(BigInt::from(n));
+    assert_eq!(binop(bi(100), bi(200), Opcode::ADD).unwrap(), bi(300));
+    assert_eq!(binop(bi(500), bi(200), Opcode::SUB).unwrap(), bi(300));
+    assert_eq!(binop(bi(12), bi(13), Opcode::MUL).unwrap(), bi(156));
+    // Integer division: 100 / 7 == 14 (spec: `10n / 3n == 3n`)
+    assert_eq!(binop(bi(100), bi(7), Opcode::DIV).unwrap(), bi(14));
+    // Remainder: 100 % 7 == 2 (spec: `10n % 3n == 1n`)
+    assert_eq!(binop(bi(100), bi(7), Opcode::MOD).unwrap(), bi(2));
+    assert_eq!(unaryop(bi(42), Opcode::NEG).unwrap(), bi(-42));
+}
+
+#[test]
+fn test_bigint_errors() {
+    let bi = |n: i64| Value::BigInt(BigInt::from(n));
+    assert!(binop_err(bi(1), bi(0), Opcode::DIV).contains("division by zero"));
+
+    // Overflow: 2^1023 * 2^1023 exceeds 128-byte cap
+    let large: BigInt = BigInt::from(1) << 1023_usize;
+    assert!(binop_err(Value::BigInt(large.clone()), Value::BigInt(large), Opcode::MUL).contains("byte limit"));
+}
+
+#[test]
+fn test_bigint_comparison() {
+    let bi = |n: i64| Value::BigInt(BigInt::from(n));
+    assert_eq!(binop(bi(100), bi(200), Opcode::CMP_LT).unwrap(), Value::Bool(true));
+}
+
+// ==========================================================================
+// BigRat: exact rational arithmetic
+// ==========================================================================
+
+#[test]
+fn test_bigrat_arithmetic() {
+    // Uses non-trivial rationals to verify normalization
+    assert_eq!(binop(bigrat(1, 3), bigrat(1, 6), Opcode::ADD).unwrap(), bigrat(1, 2));  // 1/3 + 1/6 = 1/2
+    assert_eq!(binop(bigrat(3, 4), bigrat(1, 4), Opcode::SUB).unwrap(), bigrat(1, 2));  // 3/4 - 1/4 = 1/2
+    assert_eq!(binop(bigrat(2, 3), bigrat(3, 4), Opcode::MUL).unwrap(), bigrat(1, 2));  // 2/3 * 3/4 = 1/2
+    // Spec: `10r / 3r == 3r + 1r/3r` i.e. 10/3
+    assert_eq!(binop(bigrat(1, 2), bigrat(1, 4), Opcode::DIV).unwrap(), bigrat(2, 1));
+    // Spec: modulus always gives 0 since (a/b)*b == a exactly
+    assert_eq!(binop(bigrat(7, 3), bigrat(2, 5), Opcode::MOD).unwrap(), bigrat(0, 1));
+    assert_eq!(unaryop(bigrat(3, 4), Opcode::NEG).unwrap(), bigrat(-3, 4));
+}
+
+#[test]
+fn test_bigrat_errors() {
+    assert!(binop_err(bigrat(1, 2), bigrat(0, 1), Opcode::DIV).contains("division by zero"));
+}
+
+#[test]
+fn test_bigrat_comparison() {
+    assert_eq!(binop(bigrat(1, 3), bigrat(1, 2), Opcode::CMP_LT).unwrap(), Value::Bool(true));
+}
+
+// ==========================================================================
+// FixedPoint: scale-aware arithmetic, C99 identity
+// ==========================================================================
+
+#[test]
+fn test_fixedpoint_add_sub() {
+    // Same-scale required; 1.50 + 2.25 = 3.75
+    assert_eq!(binop(fixed(150, 2), fixed(225, 2), Opcode::ADD).unwrap(), fixed(375, 2));
+    // 5.00 - 3.25 = 1.75
+    assert_eq!(binop(fixed(500, 2), fixed(325, 2), Opcode::SUB).unwrap(), fixed(175, 2));
+}
+
+#[test]
+fn test_fixedpoint_mul_doubles_scale() {
+    // Spec: scale doubles on multiplication. 1.5p1 * 2.0p1 = 3.00p2
+    assert_eq!(binop(fixed(15, 1), fixed(20, 1), Opcode::MUL).unwrap(), fixed(300, 2));
+}
+
+#[test]
+fn test_fixedpoint_div_and_mod_c99() {
+    // Spec: `10p1 / 3p1 == 3.3p1` (shifted integer division)
+    assert_eq!(binop(fixed(100, 1), fixed(30, 1), Opcode::DIV).unwrap(), fixed(33, 1));
+    // Spec: `10p1 % 3p1 == 0.1p1`, satisfying C99 identity (a/b)*b + a%b == a
+    assert_eq!(binop(fixed(100, 1), fixed(30, 1), Opcode::MOD).unwrap(), fixed(1, 1));
+    // Exact division: 6.0p1 % 3.0p1 = 0.0p1
+    assert_eq!(binop(fixed(60, 1), fixed(30, 1), Opcode::MOD).unwrap(), fixed(0, 1));
+}
+
+#[test]
+fn test_fixedpoint_neg_and_errors() {
+    assert_eq!(unaryop(fixed(150, 2), Opcode::NEG).unwrap(), fixed(-150, 2));
+    // Different scales -> type mismatch
+    assert!(binop_err(fixed(150, 2), fixed(15, 1), Opcode::ADD).contains("type mismatch"));
+    // Division by zero
+    assert!(binop_err(fixed(100, 1), fixed(0, 1), Opcode::DIV).contains("division by zero"));
+    assert!(binop_err(fixed(100, 1), fixed(0, 1), Opcode::MOD).contains("division by zero"));
+}
+
+// ==========================================================================
+// Cross-type errors: no implicit coercion
+// ==========================================================================
+
+#[test]
+fn test_cross_type_errors() {
+    let bi = Value::BigInt(BigInt::from(1));
+    // Int + Float
+    assert!(binop_err(Value::Int(1), Value::Float(1.0), Opcode::ADD).contains("type mismatch"));
+    // BigInt * BigRat
+    assert!(binop_err(bi.clone(), bigrat(1, 2), Opcode::MUL).contains("type mismatch"));
+    // Float - BigInt
+    assert!(binop_err(Value::Float(1.0), bi, Opcode::SUB).contains("type mismatch"));
+}

--- a/rholang-vm/tests/numeric_types_tests.rs
+++ b/rholang-vm/tests/numeric_types_tests.rs
@@ -68,7 +68,7 @@ fn test_float_arithmetic() {
     assert_eq!(binop(Value::Float(5.0), Value::Float(3.0), Opcode::SUB).unwrap(), Value::Float(2.0));
     assert_eq!(binop(Value::Float(2.5), Value::Float(4.0), Opcode::MUL).unwrap(), Value::Float(10.0));
     assert_eq!(binop(Value::Float(10.0), Value::Float(4.0), Opcode::DIV).unwrap(), Value::Float(2.5));
-    assert_eq!(unaryop(Value::Float(3.14), Opcode::NEG).unwrap(), Value::Float(-3.14));
+    assert_eq!(unaryop(Value::Float(3.15), Opcode::NEG).unwrap(), Value::Float(-3.15));
 }
 
 #[test]
@@ -114,10 +114,7 @@ fn test_bigint_arithmetic() {
 fn test_bigint_errors() {
     let bi = |n: i64| Value::BigInt(BigInt::from(n));
     assert!(binop_err(bi(1), bi(0), Opcode::DIV).contains("division by zero"));
-
-    // Overflow: 2^1023 * 2^1023 exceeds 128-byte cap
-    let large: BigInt = BigInt::from(1) << 1023_usize;
-    assert!(binop_err(Value::BigInt(large.clone()), Value::BigInt(large), Opcode::MUL).contains("byte limit"));
+    assert!(binop_err(bi(1), bi(0), Opcode::MOD).contains("division by zero"));
 }
 
 #[test]
@@ -148,6 +145,16 @@ fn test_bigrat_errors() {
     assert!(binop_err(bigrat(1, 2), bigrat(0, 1), Opcode::DIV).contains("division by zero"));
 }
 
+// ==========================================================================
+// Signed integer: division by zero
+// ==========================================================================
+
+#[test]
+fn test_int_division_by_zero() {
+    assert!(binop_err(Value::Int(10), Value::Int(0), Opcode::DIV).contains("division by zero"));
+    assert!(binop_err(Value::Int(10), Value::Int(0), Opcode::MOD).contains("division by zero"));
+}
+
 #[test]
 fn test_bigrat_comparison() {
     assert_eq!(binop(bigrat(1, 3), bigrat(1, 2), Opcode::CMP_LT).unwrap(), Value::Bool(true));
@@ -166,9 +173,13 @@ fn test_fixedpoint_add_sub() {
 }
 
 #[test]
-fn test_fixedpoint_mul_doubles_scale() {
-    // Spec: scale doubles on multiplication. 1.5p1 * 2.0p1 = 3.00p2
-    assert_eq!(binop(fixed(15, 1), fixed(20, 1), Opcode::MUL).unwrap(), fixed(300, 2));
+fn test_fixedpoint_mul_preserves_scale() {
+    // Scale-preserving: 1.5p1 * 2.0p1 = 3.0p1 (unscaled: (15*20)/10 = 30)
+    assert_eq!(binop(fixed(15, 1), fixed(20, 1), Opcode::MUL).unwrap(), fixed(30, 1));
+    // Precision loss: 0.1p1 * 0.1p1 = 0.0p1 (unscaled: (1*1)/10 = 0, floor)
+    assert_eq!(binop(fixed(1, 1), fixed(1, 1), Opcode::MUL).unwrap(), fixed(0, 1));
+    // Scale mismatch is an error
+    assert!(binop_err(fixed(15, 1), fixed(150, 2), Opcode::MUL).contains("type mismatch"));
 }
 
 #[test]

--- a/rholang-wasm/Cargo.toml
+++ b/rholang-wasm/Cargo.toml
@@ -27,6 +27,7 @@ rholang-lib = { path = "../rholang-lib", optional = true }
 rholang-interpreter = { path = "../rholang-interpreter", default-features = false, optional = true }
 validated = { workspace = true }
 anyhow = { workspace = true }
+num-bigint = { workspace = true }
 futures = "0.3"
 
 [features]

--- a/rholang-wasm/src/lib.rs
+++ b/rholang-wasm/src/lib.rs
@@ -35,6 +35,12 @@ fn pretty_value(v: &Value) -> String {
             let elems: Vec<String> = ps.iter().map(|p| format!("<{}>", p.source_ref())).collect();
             format!("Par({})", elems.join(" | "))
         }
+        Value::Float(f) => format!("Float({})", f),
+        Value::BigInt(n) => format!("BigInt({}n)", n),
+        Value::BigRat(r) => format!("BigRat({}r/{}r)", r.numer(), r.denom()),
+        Value::FixedPoint { unscaled, scale } => {
+            format!("FixedPoint({}p{})", unscaled, scale)
+        }
         Value::Nil => "Nil".to_string(),
     }
 }


### PR DESCRIPTION
## Summary

Implements the Rholang numeric types spec (Michael Stay, 2025-11-13), adding four new numeric types to the VM, compiler, and runtime:

- **Float** (`f64`) — IEEE 754 double precision, suffix `f32`/`f64`. NaN != NaN, MOD rejected per spec.
- **BigInt** — arbitrary-precision signed integers, suffix `n`. No size cap — gas scales with operand size.
- **BigRat** — exact rationals as ratio of BigInts, suffix `r`. MOD always returns 0. Auto-reduced to lowest terms via GCD (`num_rational::BigRational`).
- **FixedPoint** — shifted BigInt with fixed decimal scale, suffix `p<scale>`. Scale-matching required for all ops. Scale-preserving multiplication with floor division. Shifted division. C99 identity `(a/b)*b + a%b == a`.

No implicit type coercion — all binary ops require matching types. Cross-type operations produce a type mismatch error.

### Key changes
- **Value enum** (`rholang-rspace`): 4 new variants, custom `PartialEq` (NaN semantics), `PartialOrd`, `Display`
- **VM execute** (`rholang-vm`): all arithmetic (ADD/SUB/MUL/DIV/MOD/NEG) and comparison opcodes extended for all types
- **Compiler codegen** (`rholang-compiler`): constant pool (`PUSH_CONST` opcode) for values that don't fit in i16 immediates, compile functions for all 6 literal types
- **Render simplification**: 4 duplicated `render_value` functions replaced with delegation to `Value::Display`

### Review feedback addressed
- Removed BigInt size cap entirely (gas is the rate limiter, not an arbitrary byte limit)
- Fixed FixedPoint multiplication: scale-preserving with floor division instead of scale-doubling
- Added signed int (`i64`) division-by-zero tests
- BigRat always in lowest terms (GCD auto-reduction via `num_rational::BigRational`)

### Open question
- FixedPoint multiplication rounding mode: currently floor division (toward -infinity). Awaiting confirmation on whether truncation toward zero or unbiased (banker's) rounding is preferred.

### Design doc reference
- `Numeric Types.md` (Michael Stay, 2025-11-13)

### Companion PR
- [f1r3node-rust PR #425](https://github.com/F1R3FLY-io/f1r3node/pull/425) — same numeric types implemented in the f1r3node-rust interpreter

## Test plan
- [x] 16 VM-level tests in `rholang-vm/tests/numeric_types_tests.rs` (arithmetic, edge cases, errors, cross-type, int div-by-zero)
- [x] 7 end-to-end compiler tests in `rholang-compiler/tests/numeric_types.rs` (parse -> compile -> execute)
- [x] Unit tests for Value equality, ordering, Display in `rholang-rspace/src/value.rs`
- [x] All pre-existing tests pass
- [x] `cargo test -p rholang-vm -p rholang-compiler -p rholang-rspace` passes with 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` clean